### PR TITLE
make wait_fixed longer for idfm

### DIFF
--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -132,7 +132,7 @@ class ArtemisTestFixture:
         self.test_counter = defaultdict(int)
 
     @classmethod
-    @pytest.yield_fixture(scope='class', autouse=True)
+    @pytest.yield_fixture(scope='module', autouse=True)
     def my_method_setup(cls, request):
         """
         method called once for each fixture

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -79,8 +79,8 @@ class DataSet(object):
                  scenario='default'):
         self.name = name
         self.scenario = scenario
-        self.reload_timeout = reload_timeout.seconds
-        self.fixed_wait = fixed_wait.seconds
+        self.reload_timeout = reload_timeout.total_seconds()
+        self.fixed_wait = fixed_wait.total_seconds()
 
     def __str__(self):
         return self.name

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -74,8 +74,8 @@ def truncate_tables(cursor, table_names_string):
 class DataSet(object):
     def __init__(self,
                  name,
-                 reload_timeout=datetime.timedelta(minutes=2),
-                 fixed_wait=datetime.timedelta(seconds=1),
+                 reload_timeout,
+                 fixed_wait,
                  scenario='default'):
         self.name = name
         self.scenario = scenario
@@ -92,7 +92,10 @@ def set_scenario(config):
         for c in cls.__bases__:
             if hasattr(c, "data_sets"):
                 for dataset in c.data_sets:
-                    cls.data_sets.append(DataSet(dataset.name, datetime.timedelta(minutes=2), dataset.scenario))
+                    cls.data_sets.append(DataSet(dataset.name,
+                                                 datetime.timedelta(minutes=2),
+                                                 datetime.timedelta(seconds=1),
+                                                 dataset.scenario))
         if config:
             for dataset in cls.data_sets:
                 conf = config.get(dataset.name, None)

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -72,10 +72,15 @@ def truncate_tables(cursor, table_names_string):
 
 
 class DataSet(object):
-    def __init__(self, name, reload_timeout=datetime.timedelta(minutes=2), scenario='default'):
+    def __init__(self,
+                 name,
+                 reload_timeout=datetime.timedelta(minutes=2),
+                 fixed_wait=datetime.timedelta(seconds=1),
+                 scenario='default'):
         self.name = name
         self.scenario = scenario
         self.reload_timeout = reload_timeout.seconds
+        self.fixed_wait = fixed_wait.seconds
 
     def __str__(self):
         return self.name
@@ -314,7 +319,7 @@ class ArtemisTestFixture:
             # we wait a bit for the kraken to be started
             try:
                 Retrying(stop_max_delay=data_set.reload_timeout * 1000,
-                         wait_fixed=100,
+                         wait_fixed=data_set.fixed_wait * 1000,
                          retry_on_result=lambda x: x != 'running') \
                     .call(kraken_status, data_set)
             except RetryError as e:

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -74,8 +74,8 @@ def truncate_tables(cursor, table_names_string):
 class DataSet(object):
     def __init__(self,
                  name,
-                 reload_timeout,
-                 fixed_wait,
+                 reload_timeout=datetime.timedelta(minutes=2),
+                 fixed_wait=datetime.timedelta(seconds=1),
                  scenario='default'):
         self.name = name
         self.scenario = scenario

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -79,8 +79,8 @@ class DataSet(object):
                  scenario='default'):
         self.name = name
         self.scenario = scenario
-        self.reload_timeout = reload_timeout.total_seconds()
-        self.fixed_wait = fixed_wait.total_seconds()
+        self.reload_timeout = reload_timeout
+        self.fixed_wait = fixed_wait
 
     def __str__(self):
         return self.name
@@ -92,10 +92,10 @@ def set_scenario(config):
         for c in cls.__bases__:
             if hasattr(c, "data_sets"):
                 for dataset in c.data_sets:
-                    cls.data_sets.append(DataSet(dataset.name,
-                                                 datetime.timedelta(minutes=2),
-                                                 datetime.timedelta(seconds=1),
-                                                 dataset.scenario))
+                    cls.data_sets.append(DataSet(name=dataset.name,
+                                                 reload_timeout=datetime.timedelta(minutes=2),
+                                                 fixed_wait=datetime.timedelta(seconds=1),
+                                                 scenario=dataset.scenario))
         if config:
             for dataset in cls.data_sets:
                 conf = config.get(dataset.name, None)
@@ -321,8 +321,8 @@ class ArtemisTestFixture:
 
             # we wait a bit for the kraken to be started
             try:
-                Retrying(stop_max_delay=data_set.reload_timeout * 1000,
-                         wait_fixed=data_set.fixed_wait * 1000,
+                Retrying(stop_max_delay=data_set.reload_timeout.total_seconds() * 1000,
+                         wait_fixed=data_set.fixed_wait.total_seconds() * 1000,
                          retry_on_result=lambda x: x != 'running') \
                     .call(kraken_status, data_set)
             except RetryError as e:

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -132,7 +132,7 @@ class ArtemisTestFixture:
         self.test_counter = defaultdict(int)
 
     @classmethod
-    @pytest.yield_fixture(scope='module', autouse=True)
+    @pytest.yield_fixture(scope='class', autouse=True)
     def my_method_setup(cls, request):
         """
         method called once for each fixture

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -17,7 +17,7 @@ IDFM_PARAMS = {
 }
 
 
-@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=2))])
+@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=10))])
 class IdfM(object):
 
     def test_idfm_0(self):

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -17,7 +17,9 @@ IDFM_PARAMS = {
 }
 
 
-@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=10))])
+@dataset([DataSet("idfm",
+                  reload_timeout=datetime.timedelta(minutes=5),
+                  fixed_wait=datetime.timedelta(seconds=10))])
 class IdfM(object):
 
     def test_idfm_0(self):

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -17,7 +17,7 @@ IDFM_PARAMS = {
 }
 
 
-@dataset([DataSet("idfm", datetime.timedelta(minutes=5))])
+@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=1))])
 class IdfM(object):
 
     def test_idfm_0(self):

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -17,7 +17,7 @@ IDFM_PARAMS = {
 }
 
 
-@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=1))])
+@dataset([DataSet("idfm", datetime.timedelta(minutes=5), datetime.timedelta(seconds=2))])
 class IdfM(object):
 
     def test_idfm_0(self):


### PR DESCRIPTION
idfm takes long time to load data during which test_mechanism request the coverage all the time, the pybreaker will short circuit the request after max nb of fail...