### PR TITLE
Remove XPASS tests

### DIFF
--- a/artemis/tests/airport01_test.py
+++ b/artemis/tests/airport01_test.py
@@ -1,8 +1,6 @@
 from artemis.test_mechanism import ArtemisTestFixture, dataset, DataSet, set_scenario
 import pytest
 
-xfail = pytest.mark.xfail
-
 
 @dataset([DataSet("airport-01")])
 class Airport1(object):
@@ -13,12 +11,10 @@ class Airport1(object):
         self.journey(_from="stop_area:AI1:SA:AIRPORTAIRPORT",
                      to="stop_area:AI1:SA:AIRPORTLYS", datetime="20120904T0700")
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01_02(self):
         self.journey(_from="stop_area:AI1:SA:AIRPORTAMS",
                      to="stop_area:AI1:SA:AIRPORTAIRPORT", datetime="20120904T0900")
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01_03(self):
         self.journey(_from="stop_area:AI1:SA:AIRPORTAIRPORT",
                      to="stop_area:AI1:SA:AIRPORTCLY", datetime="20120908T1000")

--- a/artemis/tests/airport_test.py
+++ b/artemis/tests/airport_test.py
@@ -1,27 +1,22 @@
 from artemis.test_mechanism import ArtemisTestFixture, dataset, DataSet, set_scenario
 import pytest
 
-xfail = pytest.mark.xfail
-
 
 @dataset([DataSet("airport")])
 class Airport(object):
     """
     TODO: put there comments about the dataset
     """
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01(self):
         self.journey(_from="stop_area:AIR:SA:AIRPORTAIRPORT",
                      to="stop_area:AIR:SA:AIRPORTLYS",
                      datetime="20120904T0700")
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_02(self):
         self.journey(_from="stop_area:AIR:SA:AIRPORTAMS",
                      to="stop_area:AIR:SA:AIRPORTAIRPORT",
                      datetime="20120904T0900")
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_03(self):
         self.journey(_from="stop_area:AIR:SA:AIRPORTAIRPORT",
                      to="stop_area:AIR:SA:AIRPORTCLY",

--- a/artemis/tests/bibus_test.py
+++ b/artemis/tests/bibus_test.py
@@ -207,15 +207,12 @@ class Bibus(object):
     def test_one_line_depth_3(self):
         self._pt_ref_call('lines', 'line:BIB:Nav1', depth=3)
 
-    @xfail(reason="we need to filter journey pattern name, we can depend on some order, and we don't care", raises=AssertionError)
     def test_one_vj_depth_1(self):
         self._pt_ref_call('vehicle_journeys', 'vehicle_journey:BIBNUIT:44_dst_1', depth=1)
 
-    @xfail(reason="we need to filter journey pattern name, we can depend on some order, and we don't care", raises=AssertionError)
     def test_one_vj_depth_2(self):
         self._pt_ref_call('vehicle_journeys', 'vehicle_journey:BIBNUIT:44_dst_1', depth=2)
 
-    @xfail(reason="we need to filter journey pattern name, we can depend on some order, and we don't care", raises=AssertionError)
     def test_one_vj_depth_3(self):
         self._pt_ref_call('vehicle_journeys', 'vehicle_journey:BIBNUIT:44_dst_1', depth=3)
 
@@ -258,7 +255,6 @@ class Bibus(object):
     """
     Other retrocompat' on API
     """
-    @xfail(reason="there is some instability on the 'quality' field", raises=AssertionError)
     def test_autocomplete(self):
         self.api('places?q=jaures')
 

--- a/artemis/tests/bibus_test.py
+++ b/artemis/tests/bibus_test.py
@@ -185,7 +185,8 @@ class Bibus(object):
     def test_one_route_depth_2(self):
         self._pt_ref_call('routes', 'route:BIB:Nav2092', depth=2)
 
-    @xfail(reason="there is some instability on the order of the stoparea list", raises=AssertionError)
+    @xfail(reason="there is some instability on the order of the stoparea list",
+           raises=AssertionError, strict=True)
     def test_one_route_depth_3(self):
         self._pt_ref_call('routes', 'route:BIB:Nav2092', depth=3)
 

--- a/artemis/tests/destineo_test.py
+++ b/artemis/tests/destineo_test.py
@@ -43,7 +43,7 @@ class Destineo(object):
                      first_section_mode=['walking', 'car'],
                      min_nb_journeys=3)
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVP-209", raises=AssertionError)
+    @xfail(reason="http://jira.canaltp.fr/browse/NAVP-209", raises=AssertionError, strict=True)
     def test_destineo_04(self):
         """
         we go to "Pazanne-Mairie-(Ste) (Sainte-Pazanne)" from "gare de Ste-Pazanne (Sainte-Pazanne)"

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -262,13 +262,13 @@ class TestGuichetUniqueDefault(GuichetUnique, ArtemisTestFixture):
 
 @set_scenario({COVERAGE: {"scenario": "new_default"}})
 class TestGuichetUniqueNewDefault(GuichetUnique, ArtemisTestFixture):
-    @xfail(reason="Unsupported new_default scenario!", raises=AssertionError)
+    @xfail(reason="Unsupported new_default scenario!", raises=AssertionError, strict=True)
     def test_guichet_unique_caen_to_marseille(self):
         super(TestGuichetUniqueNewDefault, self).test_guichet_unique_caen_to_marseille()
 
 
 @set_scenario({COVERAGE: {"scenario": "experimental"}})
 class TestGuichetUniqueExperimental(GuichetUnique, ArtemisTestFixture):
-    @xfail(reason="Unsupported experimental scenario!", raises=AssertionError)
+    @xfail(reason="Unsupported experimental scenario!", raises=AssertionError, strict=True)
     def test_guichet_unique_caen_to_marseille(self):
         super(TestGuichetUniqueExperimental, self).test_guichet_unique_caen_to_marseille()

--- a/artemis/tests/itl_test.py
+++ b/artemis/tests/itl_test.py
@@ -1,6 +1,6 @@
 from artemis.test_mechanism import ArtemisTestFixture, dataset, DataSet, set_scenario
 import pytest
-xfail = pytest.mark.xfail
+
 
 @dataset([DataSet("itl")])
 class Itl(object):

--- a/artemis/tests/sherbrooke_test.py
+++ b/artemis/tests/sherbrooke_test.py
@@ -1,6 +1,5 @@
 from artemis.test_mechanism import ArtemisTestFixture, dataset, DataSet, set_scenario
 import pytest
-xfail = pytest.mark.xfail
 
 
 @dataset([DataSet("sherbrooke")])


### PR DESCRIPTION
This PR won't be merged as is, but all the commits should be studied and discussed as there is a bit of cleaning to be done :construction:

The goal is to remove xfail in code as there is no argument on having it since forever.