### PR TITLE
Clean Kirin db at each test, only for GuichetUnique

### DIFF
--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1,9 +1,15 @@
+from artemis.common_fixture import clean_kirin_db
 from artemis.test_mechanism import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 
 xfail = pytest.mark.xfail
 COVERAGE = "guichet-unique"
+
+
+@pytest.fixture(scope='function', autouse=True)
+def clean_kirin_db_before_each_test():
+    return clean_kirin_db()
 
 
 @dataset([DataSet(COVERAGE)])
@@ -278,7 +284,6 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="base_schedule")
 
-    @xfail(reason="Waiting for fix - NAVP-1135", raises=AssertionError)
     def test_kirin_cots_trip_add_new_stop_point_in_the_middle(self):
         """
         Test add a stop_time in the middle of the vj


### PR DESCRIPTION
Also reactivate test_kirin_cots_trip_add_new_stop_point_in_the_middle that was not chaining well with previous test.

JIRA: https://jira.kisio.org/browse/NAVP-1135
Please have a look at the limitations commented in JIRA

TODO (`do_not_merge` labels that):

- [x] wait for the build of the branch to complete : https://ci.navitia.io/job/custom_artemis_reference_branch_and_artemis_branch_build/189/console