### PR TITLE
create new base cots + update delays cots

### DIFF
--- a/artemis/tests/fixtures/trip_base_9580_tgv.json
+++ b/artemis/tests/fixtures/trip_base_9580_tgv.json
@@ -379,29 +379,9 @@
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T16:09:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
         "rang": 8,
         "typeArret": "CH"
       },
@@ -437,36 +417,10 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T17:03:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T17:05:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
         "rang": 9,
         "typeArret": "CH"
       },
@@ -502,36 +456,10 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T18:06:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T18:16:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
         "rang": 10,
         "typeArret": "CH"
       },
@@ -567,36 +495,10 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T19:18:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T19:21:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
         "rang": 11,
         "typeArret": "CH"
       },
@@ -632,36 +534,10 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T19:41:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeHoraireProjeteDepart": [
-          {
-            "dateHeure": "2012-11-20T19:44:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifArrivee": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
-        "listeMotifDepart": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
         "rang": 12,
         "typeArret": "CH"
       },
@@ -684,22 +560,9 @@
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
-        "listeHoraireProjeteArrivee": [
-          {
-            "dateHeure": "2012-11-20T19:56:00+0000",
-            "dateHeureEmission": "2012-11-20T08:35:06+0000",
-            "pronosticBrut": 780,
-            "pronosticIV": 600,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeHoraireProjeteArrivee": [],
         "listeHoraireProjeteDepart": [],
-        "listeMotifArrivee": [
-          {
-            "idMotifInterne": 8,
-            "source": "IRE-GOP"
-          }
-        ],
+        "listeMotifArrivee": [],
         "listeMotifDepart": [],
         "rang": 13,
         "typeArret": "CH"

--- a/artemis/tests/fixtures/trip_base_9580_tgv.json
+++ b/artemis/tests/fixtures/trip_base_9580_tgv.json
@@ -100,7 +100,7 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:01:00+0000",
+          "dateHeure": "2012-11-20T13:01:00+0000",
           "heureLocale": "14:01:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -133,13 +133,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T12:37:00+0000",
+          "dateHeure": "2012-11-20T13:37:00+0000",
           "heureLocale": "14:37:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:40:00+0000",
+          "dateHeure": "2012-11-20T13:40:00+0000",
           "heureLocale": "14:40:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -172,13 +172,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T13:02:00+0000",
+          "dateHeure": "2012-11-20T14:02:00+0000",
           "heureLocale": "15:02:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T13:12:00+0000",
+          "dateHeure": "2012-11-20T14:12:00+0000",
           "heureLocale": "15:12:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -211,13 +211,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T13:31:00+0000",
+          "dateHeure": "2012-11-20T14:31:00+0000",
           "heureLocale": "15:31:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T13:34:00+0000",
+          "dateHeure": "2012-11-20T14:34:00+0000",
           "heureLocale": "15:34:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -250,13 +250,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T14:03:00+0000",
+          "dateHeure": "2012-11-20T15:03:00+0000",
           "heureLocale": "16:03:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T14:12:00+0000",
+          "dateHeure": "2012-11-20T15:12:00+0000",
           "heureLocale": "16:12:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -289,13 +289,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T14:59:00+0000",
+          "dateHeure": "2012-11-20T15:59:00+0000",
           "heureLocale": "16:59:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:08:00+0000",
+          "dateHeure": "2012-11-20T16:08:00+0000",
           "heureLocale": "17:08:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -328,13 +328,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T15:30:00+0000",
+          "dateHeure": "2012-11-20T16:30:00+0000",
           "heureLocale": "17:30:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:33:00+0000",
+          "dateHeure": "2012-11-20T16:33:00+0000",
           "heureLocale": "17:33:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -367,13 +367,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T15:54:00+0000",
+          "dateHeure": "2012-11-20T16:54:00+0000",
           "heureLocale": "17:54:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:59:00+0000",
+          "dateHeure": "2012-11-20T16:59:00+0000",
           "heureLocale": "17:59:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -406,13 +406,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T16:53:00+0000",
+          "dateHeure": "2012-11-20T17:53:00+0000",
           "heureLocale": "18:54:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T16:55:00+0000",
+          "dateHeure": "2012-11-20T17:55:00+0000",
           "heureLocale": "18:56:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -445,13 +445,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T17:56:00+0000",
+          "dateHeure": "2012-11-20T18:56:00+0000",
           "heureLocale": "19:56:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T18:06:00+0000",
+          "dateHeure": "2012-11-20T19:06:00+0000",
           "heureLocale": "20:06:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -484,13 +484,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:08:00+0000",
+          "dateHeure": "2012-11-20T20:08:00+0000",
           "heureLocale": "21:08:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T19:11:00+0000",
+          "dateHeure": "2012-11-20T20:11:00+0000",
           "heureLocale": "21:11:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -523,13 +523,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:31:00+0000",
+          "dateHeure": "2012-11-20T20:31:00+0000",
           "heureLocale": "21:31:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T19:34:00+0000",
+          "dateHeure": "2012-11-20T20:34:00+0000",
           "heureLocale": "21:34:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -555,7 +555,7 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:46:00+0000",
+          "dateHeure": "2012-11-20T20:46:00+0000",
           "heureLocale": "21:46:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0

--- a/artemis/tests/fixtures/trip_delay_9580_tgv.json
+++ b/artemis/tests/fixtures/trip_delay_9580_tgv.json
@@ -100,7 +100,7 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:01:00+0000",
+          "dateHeure": "2012-11-20T13:01:00+0000",
           "heureLocale": "14:01:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -133,13 +133,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T12:37:00+0000",
+          "dateHeure": "2012-11-20T13:37:00+0000",
           "heureLocale": "14:37:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T12:40:00+0000",
+          "dateHeure": "2012-11-20T13:40:00+0000",
           "heureLocale": "14:40:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -172,13 +172,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T13:02:00+0000",
+          "dateHeure": "2012-11-20T14:02:00+0000",
           "heureLocale": "15:02:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T13:12:00+0000",
+          "dateHeure": "2012-11-20T14:12:00+0000",
           "heureLocale": "15:12:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -211,13 +211,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T13:31:00+0000",
+          "dateHeure": "2012-11-20T14:31:00+0000",
           "heureLocale": "15:31:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T13:34:00+0000",
+          "dateHeure": "2012-11-20T14:34:00+0000",
           "heureLocale": "15:34:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -250,13 +250,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T14:03:00+0000",
+          "dateHeure": "2012-11-20T15:03:00+0000",
           "heureLocale": "16:03:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T14:12:00+0000",
+          "dateHeure": "2012-11-20T15:12:00+0000",
           "heureLocale": "16:12:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -289,13 +289,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T14:59:00+0000",
+          "dateHeure": "2012-11-20T15:59:00+0000",
           "heureLocale": "16:59:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:08:00+0000",
+          "dateHeure": "2012-11-20T16:08:00+0000",
           "heureLocale": "17:08:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -328,13 +328,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T15:30:00+0000",
+          "dateHeure": "2012-11-20T16:30:00+0000",
           "heureLocale": "17:30:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:33:00+0000",
+          "dateHeure": "2012-11-20T16:33:00+0000",
           "heureLocale": "17:33:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -367,13 +367,13 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T15:54:00+0000",
+          "dateHeure": "2012-11-20T16:54:00+0000",
           "heureLocale": "17:54:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T15:59:00+0000",
+          "dateHeure": "2012-11-20T16:59:00+0000",
           "heureLocale": "17:59:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
@@ -426,20 +426,20 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T16:53:00+0000",
+          "dateHeure": "2012-11-20T17:53:00+0000",
           "heureLocale": "18:54:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T16:55:00+0000",
+          "dateHeure": "2012-11-20T17:55:00+0000",
           "heureLocale": "18:56:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T17:03:00+0000",
+            "dateHeure": "2012-11-20T18:03:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -448,7 +448,7 @@
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T17:05:00+0000",
+            "dateHeure": "2012-11-20T18:05:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -491,20 +491,20 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T17:56:00+0000",
+          "dateHeure": "2012-11-20T18:56:00+0000",
           "heureLocale": "19:56:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T18:06:00+0000",
+          "dateHeure": "2012-11-20T19:06:00+0000",
           "heureLocale": "20:06:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T18:06:00+0000",
+            "dateHeure": "2012-11-20T19:06:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -513,7 +513,7 @@
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T18:16:00+0000",
+            "dateHeure": "2012-11-20T19:16:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -556,20 +556,20 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:08:00+0000",
+          "dateHeure": "2012-11-20T20:08:00+0000",
           "heureLocale": "21:08:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T19:11:00+0000",
+          "dateHeure": "2012-11-20T20:11:00+0000",
           "heureLocale": "21:11:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T19:18:00+0000",
+            "dateHeure": "2012-11-20T20:18:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -578,7 +578,7 @@
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T19:21:00+0000",
+            "dateHeure": "2012-11-20T20:21:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -621,20 +621,20 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:31:00+0000",
+          "dateHeure": "2012-11-20T20:31:00+0000",
           "heureLocale": "21:31:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurDepart": {
-          "dateHeure": "2012-11-20T19:34:00+0000",
+          "dateHeure": "2012-11-20T20:34:00+0000",
           "heureLocale": "21:34:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T19:41:00+0000",
+            "dateHeure": "2012-11-20T20:41:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -643,7 +643,7 @@
         ],
         "listeHoraireProjeteDepart": [
           {
-            "dateHeure": "2012-11-20T19:44:00+0000",
+            "dateHeure": "2012-11-20T20:44:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,
@@ -679,14 +679,14 @@
           "nbJoursPasseMinuit": 0
         },
         "horaireVoyageurArrivee": {
-          "dateHeure": "2012-11-20T19:46:00+0000",
+          "dateHeure": "2012-11-20T20:46:00+0000",
           "heureLocale": "21:46:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0
         },
         "listeHoraireProjeteArrivee": [
           {
-            "dateHeure": "2012-11-20T19:56:00+0000",
+            "dateHeure": "2012-11-20T20:56:00+0000",
             "dateHeureEmission": "2012-11-20T08:35:06+0000",
             "pronosticBrut": 780,
             "pronosticIV": 600,


### PR DESCRIPTION
Until now, COTS in Artemis are wrong.
We have differents errors like: _schedules, stop point list, etc.._

This PR aims to create a `base COTS flow`. You can **derivate** it to develop differents cases.

I did this job, before starting https://jira.kisio.org/browse/NAVP-1099, case 1
In addtion, I updated _trip_delay_9580_tgv.json_ with good params too.

We have new reference because I change delays (10 min) : https://github.com/CanalTP/artemis_references/pull/153

The base COTS is based on the classical 

- 14:01 > 14:01 gare de Frankfurt-am-Main-Hbf
- etc ...
- 21:46 > 21:46 gare de Marseille-St-Charles

![classical](https://user-images.githubusercontent.com/32099204/51471620-8a4b1180-1d77-11e9-92af-7e4d5bd3add2.png)
