### PR TITLE
Fix after kirin correction for read of add+delay

### DIFF
--- a/artemis/tests/fixtures/trip_add_several_new_stop_points_in_one_cots_9580_tgv.json
+++ b/artemis/tests/fixtures/trip_add_several_new_stop_points_in_one_cots_9580_tgv.json
@@ -93,13 +93,7 @@
 
 			},
 			"listeHoraireProjeteArrivee": [],
-			"listeHoraireProjeteDepart": [{
-				"dateHeure": "2012-11-20T12:35:00+0000",
-				"dateHeureEmission": "2012-11-20T08:35:06+0000",
-				"pronosticBrut": 1920,
-				"pronosticIV": 1800,
-				"source": "IRE-GOP"
-			}],
+			"listeHoraireProjeteDepart": [],
 			"listeMotifArrivee": [],
 			"listeMotifDepart": [],
 			"rang": 1,


### PR DESCRIPTION
As delays are now correctly read, this one was inconsistent

TODO:

- [ ] merge https://github.com/CanalTP/kirin/pull/226