### PR TITLE
artemis: tests added on trip add chaining with some options

### DIFF
--- a/artemis/tests/fixtures/trip_add_paris_marseille.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille.json
@@ -1,0 +1,319 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeRelation": "671",
+    "codeService": "A2018",
+    "codeSousRelation": "671100",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idMotifInterneReference": 8,
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "391003",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:10:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:00:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 0,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "AJOUTEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a"
+  }
+}

--- a/artemis/tests/fixtures/trip_add_paris_marseille_delete_with_delay_15_and_stop_time_added.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_delete_with_delay_15_and_stop_time_added.json
@@ -1,0 +1,382 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "686667",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "543009",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T11:30:00+0000",
+          "heureLocale": "12:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T11:45:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:55:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "14:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 5,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "SUPPRIMEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/artemis/tests/fixtures/trip_add_paris_marseille_to_normal.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_to_normal.json
@@ -1,0 +1,215 @@
+{
+  "ressource": "courseOPE",
+  "mode": "creation",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "391003",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15.json
@@ -1,0 +1,327 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "391003",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_added.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_added.json
@@ -1,0 +1,382 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "391003",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "543009",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T11:30:00+0000",
+          "heureLocale": "12:30:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T11:45:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:55:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:40:00+0000",
+          "heureLocale": "12:40:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 5,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 6,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_deleted.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_deleted.json
@@ -1,0 +1,327 @@
+{
+  "ressource": "courseOPE",
+  "mode": "modification",
+  "evt": [
+    "PERTURBATION"
+  ],
+  "PdPObserveArrivee": [],
+  "PdPObserveDepart": [],
+  "PdPPronosticBrutArrivee": [
+    "0f4666b5-082f-4006-9e06-65702e45fdda",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticBrutDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVArrivee": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPPronosticIVDepart": [
+    "a75a7cd7-8428-4c45-ab0d-dc21a4ccc928",
+    "06c8be2a-b35f-4aee-889a-b1965a040289"
+  ],
+  "PdPImpacteDepart": [],
+  "PdPImpacteArrivee": [],
+  "nouvelleVersion": {
+    "codeCompagnieTransporteur": "1187",
+    "codeMarqueTransporteur": "TGV",
+    "codeService": "A2018",
+    "codeTransporteurResponsable": "1S",
+    "dateDebutService": "2012-09-13",
+    "dateFinService": "2012-12-31",
+    "estDiscontinue": false,
+    "estTechnique": false,
+    "etat": "ACTIVE",
+    "idVersion": "c07a8b24-b1bb-454b-9d92-73d40de285ec",
+    "identifiantDansSystemeCreateur": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "indicateurFer": "FERRE",
+    "listeCouplageCourseOPE": [],
+    "listeCodeTransporteurAssocie": [],
+    "listeEvenement": [],
+    "listeJourRegimeDApplication": [
+      {
+        "date": "2012-11-20"
+      }
+    ],
+    "listeJourRegimeFacultatif": [],
+    "listeMotif": [
+      {
+        "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+        "idMotifInterne": 8,
+        "source": "IRE-GOP"
+      }
+    ],
+    "listePointDeParcours": [
+      {
+        "@id": "c1e2630a-d92a-4e0a-9010-a4e11c0fc777",
+        "cr": "0087",
+        "ci": "391003",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T11:00:00+0000",
+          "heureLocale": "12:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T11:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 1,
+        "typeArret": "CH"
+      },
+      {
+        "@id": "1022221f-3223-423a-8541-b32f2878b8d8",
+        "cr": "0087",
+        "ci": "683573",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T12:00:00+0000",
+          "heureLocale": "13:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "SUPPRESSION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T12:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T12:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 2,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T12:10:00+0000",
+          "heureLocale": "13:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "1025211f-3543-452a-8d61-bd2f2868bad8",
+        "cr": "0087",
+        "ci": "318964",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T14:00:00+0000",
+          "heureLocale": "15:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T14:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T14:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 3,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T14:10:00+0000",
+          "heureLocale": "15:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "06c8be2a-b35f-4aee-889a-b1965a040289",
+        "cr": "0087",
+        "ci": "319012",
+        "ch": "00",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T15:00:00+0000",
+          "heureLocale": "16:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T15:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [
+          {
+            "dateHeure": "2012-11-20T15:25:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "rang": 4,
+        "typeArret": "CH",
+        "horaireVoyageurDepart": {
+          "dateHeure": "2012-11-20T15:10:00+0000",
+          "heureLocale": "16:10:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        }
+      },
+      {
+        "@id": "0f4666b5-082f-4006-9e06-65702e45fdda",
+        "cr": "0087",
+        "ci": "751008",
+        "ch": "BV",
+        "timeZoneLocale": "Europe/Paris",
+        "horaireVoyageurArrivee": {
+          "dateHeure": "2012-11-20T16:00:00+0000",
+          "heureLocale": "17:00:00",
+          "idFuseauHoraire": "Europe/Paris",
+          "nbJoursPasseMinuit": 0,
+          "statutCirculationOPE": "CREATION"
+        },
+        "listeHoraireProjeteArrivee": [
+          {
+            "dateHeure": "2012-11-20T16:15:00+0000",
+            "dateHeureEmission": "2012-11-20T08:35:06+0000",
+            "pronosticBrut": 780,
+            "source": "IRE-GOP",
+            "pronosticIV": 900
+          }
+        ],
+        "listeHoraireProjeteDepart": [],
+        "listeMotifArrivee": [
+          {
+            "dateHeureDeclaration": "2012-11-20T08:35:06+0000",
+            "idMotifInterne": 78,
+            "source": "IRE-GOP"
+          }
+        ],
+        "listeMotifDepart": [],
+        "rang": 5,
+        "typeArret": "CH"
+      }
+    ],
+    "listeService": [],
+    "listeSubstitutionCourse": [],
+    "listeUtilisationSillon": [
+      {
+        "identifiantSillon": {
+          "numeroOperationnelSillon": "9580-9581",
+          "sillonTTH": "042522910097"
+        },
+        "listeJourRegimeDApplication": [
+          {
+            "date": "2012-11-20"
+          }
+        ],
+        "listeJourRegimeFacultatif": [],
+        "pointDebutUtilisationSillon": {
+          "@id": "50f31367-af56-4c08-9bf8-423bf3856dfc"
+        },
+        "pointFinUtilisationSillon": {
+          "@id": "0f4666b5-082f-4006-9e06-65702e45fdda"
+        },
+        "porteur": true,
+        "rangPRDebutUtilisationSillon": 1,
+        "decalagePasseMinuit": 0,
+        "rangPRFinUtilisationSillon": 210
+      }
+    ],
+    "numeroCourse": "151515",
+    "statutOperationnel": "PERTURBEE",
+    "systemeCreateur": "2148",
+    "type": "COURSE_OPE",
+    "@id": "784ec6d2-ba7b-4c6d-ab96-da03e163345a",
+    "dateDerniereModification": "2019-01-23T08:35:06+0000",
+    "idMotifInterneReference": 8,
+    "codeRelation": "671",
+    "codeSousRelation": "671100"
+  }
+}

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1053,15 +1053,13 @@ class GuichetUnique(object):
                      data_freshness="realtime")
 
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
-    def test_kirin_cots_add_trip_chain_type_1(self):
+    def test_kirin_cots_add_trip_sequence_11(self):
         """
-        Test for case 11 from the file "Enchainement Cas_API_20181010.xlsx"
-        1. A simple trip add with 5 stop_times all existing in navitia
+        1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Return to normal
         """
         """
-        Base and realtime request
         Requested datetime: 2012/11/20 11:55:00
         From: gare de Paris-Montparnasse 1-2 (Paris)
         To:   gare de Marseille-St-Charles (Marseille)
@@ -1128,16 +1126,14 @@ class GuichetUnique(object):
                      data_freshness="realtime")
 
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
-    def test_kirin_cots_add_trip_chain_type_2(self):
+    def test_kirin_cots_add_trip_sequence_12(self):
         """
-        Test for case 12 from the file "Enchainement Cas_API_20181010.xlsx"
-        1. A simple trip add with 5 stop_times all existing in navitia
+        1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a stop_time (gare de Auxerre-St-Gervais) deleted in the above flux cots
         4. Return to normal
         """
         """
-        Base and realtime request
         Requested datetime: 2012/11/20 12:55:00
         From: gare de Auxerre-St-Gervais
         To:   gare de Marseille-St-Charles (Marseille)
@@ -1219,17 +1215,15 @@ class GuichetUnique(object):
                      data_freshness="realtime")
 
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
-    def test_kirin_cots_add_trip_chain_type_3(self):
+    def test_kirin_cots_add_trip_sequence_2(self):
         """
-        Test for case 2 from the file "Enchainement Cas_API_20181010.xlsx" (from 1 to 4)
-        1. A simple trip add with 5 stop_times all existing in navitia
+        1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a new stop_time (gare de Orleans) added in the above flux cots
         4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
         5. Add again the same trip as 1.
         """
         """
-        Base and realtime request
         Requested datetime: 2012/11/20 12:55:00
         From: gare de Orleans
         To:   gare de Marseille-St-Charles (Marseille)

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1055,6 +1055,7 @@ class GuichetUnique(object):
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_chain_type_1(self):
         """
+        Test for case 11 from the file "Enchainement Cas_API_20181010.xlsx"
         1. A simple trip add with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Return to normal
@@ -1129,6 +1130,7 @@ class GuichetUnique(object):
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_chain_type_2(self):
         """
+        Test for case 12 from the file "Enchainement Cas_API_20181010.xlsx"
         1. A simple trip add with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a stop_time (gare de Auxerre-St-Gervais) deleted in the above flux cots
@@ -1219,10 +1221,12 @@ class GuichetUnique(object):
     @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_chain_type_3(self):
         """
+        Test for case 2 from the file "Enchainement Cas_API_20181010.xlsx" (from 1 to 4)
         1. A simple trip add with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a new stop_time (gare de Orleans) added in the above flux cots
         4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
+        5. Add again the same trip as 1.
         """
         """
         Base and realtime request
@@ -1301,6 +1305,23 @@ class GuichetUnique(object):
         Should have a no-solution as the trip has been deleted
         """
         self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Add the trip recently deleted above
+        """
+        self.send_and_wait('trip_add_paris_marseille.json')
+
+        """
+        Realtime request with datetime: 2012/11/20 12:55:00
+        From: gare de Auxerre-St-Gervais
+        To:   gare de Marseille-St-Charles (Marseille)
+        Should have a solution with departure at 13:00 and arrival at 17:00
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
                      to="stop_area:OCE:SA:87751008",
                      datetime="20121120T125500",
                      max_nb_transfers="0",

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1052,6 +1052,260 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="realtime")
 
+    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
+    def test_kirin_cots_add_trip_chain_type_1(self):
+        """
+        1. A simple trip add with 5 stop_times all existing in navitia
+        2. Trip modified with 15 minutes delay in each stop_times
+        3. Return to normal
+        """
+        """
+        Base and realtime request
+        Requested datetime: 2012/11/20 11:55:00
+        From: gare de Paris-Montparnasse 1-2 (Paris)
+        To:   gare de Marseille-St-Charles (Marseille)
+        Should have a no-solution for both requests
+        """
+        self.journey(_from="stop_area:OCE:SA:87391003",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T115500",
+                     max_nb_transfers="0",
+                     data_freshness="base_schedule")
+
+        self.journey(_from="stop_area:OCE:SA:87391003",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T115500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Add a new trip with:
+        depart: gare de Paris-Montparnasse 1-2 (Paris) at 12:00:00
+        destination: gare de Marseille-St-Charles (Marseille) at 17:00:00
+        and 3 stations in between
+        """
+        self.send_and_wait('trip_add_paris_marseille.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 12:00 and arrival at 17:00
+        """
+        self.journey(_from="stop_area:OCE:SA:87391003",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T115500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        All stop times in the trip are delayed by 15 minutes.
+        """
+        self.send_and_wait('trip_add_paris_marseille_with_delay_15.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 12:15 and arrival at 17:15
+        """
+        self.journey(_from="stop_area:OCE:SA:87391003",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T115500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Return to normal without any delay
+        """
+        self.send_and_wait('trip_add_paris_marseille_to_normal.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 12:00 and arrival at 17:00
+        """
+        self.journey(_from="stop_area:OCE:SA:87391003",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T115500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
+    def test_kirin_cots_add_trip_chain_type_2(self):
+        """
+        1. A simple trip add with 5 stop_times all existing in navitia
+        2. Trip modified with 15 minutes delay in each stop_times
+        3. Trip modified with a stop_time (gare de Auxerre-St-Gervais) deleted in the above flux cots
+        4. Return to normal
+        """
+        """
+        Base and realtime request
+        Requested datetime: 2012/11/20 12:55:00
+        From: gare de Auxerre-St-Gervais
+        To:   gare de Marseille-St-Charles (Marseille)
+        Should have a no-solution for both requests
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="base_schedule")
+
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Add a new trip with:
+        depart: gare de Paris-Montparnasse 1-2 (Paris) at 12:00:00
+        destination: gare de Marseille-St-Charles (Marseille) at 17:00:00
+        and 3 stations in between
+        """
+        self.send_and_wait('trip_add_paris_marseille.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 13:00 and arrival at 17:00
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        All stop times in the trip are delayed by 15 minutes.
+        """
+        self.send_and_wait('trip_add_paris_marseille_with_delay_15.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 13:15 and arrival at 17:15
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Delete the second station "gare de Auxerre-St-Gervais" in the recently added trip with 15 minutes delay 
+        """
+        self.send_and_wait('trip_add_paris_marseille_with_delay_15_and_stop_time_deleted.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a no-solution as the departure station is deleted
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Return to normal without any delay
+        """
+        self.send_and_wait('trip_add_paris_marseille_to_normal.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 13:00 and arrival at 17:00
+        """
+        self.journey(_from="stop_area:OCE:SA:87683573",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
+    def test_kirin_cots_add_trip_chain_type_3(self):
+        """
+        1. A simple trip add with 5 stop_times all existing in navitia
+        2. Trip modified with 15 minutes delay in each stop_times
+        3. Trip modified with a new stop_time (gare de Orleans) added in the above flux cots
+        4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
+        """
+        """
+        Base and realtime request
+        Requested datetime: 2012/11/20 12:55:00
+        From: gare de Orleans
+        To:   gare de Marseille-St-Charles (Marseille)
+        Should have a no-solution for both requests
+        """
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="base_schedule")
+
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Add a new trip with:
+        depart: gare de Paris-Montparnasse 1-2 (Paris) at 12:00:00
+        destination: gare de Marseille-St-Charles (Marseille) at 17:00:00
+        and 3 stations in between
+        """
+        self.send_and_wait('trip_add_paris_marseille.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a no-solution as the departure station doesn't exist in recently added trip
+        """
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        All stop times in the trip are delayed by 15 minutes.
+        """
+        self.send_and_wait('trip_add_paris_marseille_with_delay_15.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a no-solution as the departure station doesn't exist in recently added trip
+        """
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Add a station "gare de Orleans" in the recently added trip with 15 minutes delay
+        """
+        self.send_and_wait('trip_add_paris_marseille_with_delay_15_and_stop_time_added.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a solution with departure at 12:55 and arrival at 17:15
+        """
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
+        """
+        Delete the recently added trip
+        """
+        self.send_and_wait('trip_add_paris_marseille_delete_with_delay_15_and_stop_time_added.json')
+
+        """
+        Realtime request with same parameters as above
+        Should have a no-solution as the trip has been deleted
+        """
+        self.journey(_from="stop_area:OCE:SA:87543009",
+                     to="stop_area:OCE:SA:87751008",
+                     datetime="20121120T125500",
+                     max_nb_transfers="0",
+                     data_freshness="realtime")
+
     def test_kirin_cots_sequence_09(self):
         """
         Sequence 09


### PR DESCRIPTION

Tests on trip add with multiple actions:

1. Add a new trip, update with a delay and update to normal
2. Add a new trip, update with a delay, update with a stop_time deleted and update to normal  
3. Add a new trip, update with a delay, update with a new stop_time and delete de trip

For details see: https://jira.kisio.org/browse/NAVP-1068