### PR TITLE
 Allow longer RT-reload on artemis

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -188,7 +188,7 @@ class ArtemisTestFixture(CommonTestFixture):
 
         return _res.get('status', {}).get('last_rt_data_loaded', object())
 
-    @retry(stop_max_delay=25000, wait_fixed=500)
+    @retry(stop_max_delay=60000, wait_fixed=500)
     def wait_for_rt_reload(self, last_rt_data_loaded, cov):
         logging.warning("waiting for rt reload later than {}".format(last_rt_data_loaded))
         rt_data_loaded = self.get_last_rt_loaded_time(cov)

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -88,7 +88,7 @@ class ArtemisTestFixture(CommonTestFixture):
             return _response.get('status', {}).get('last_load_at', "")
 
         # wait 5 min at most
-        @retry(stop_max_delay=3000000, wait_fixed=5000)
+        @retry(stop_max_delay=300000, wait_fixed=500)
         def wait_for_kraken_reload(last_data_loaded, cov):
             new_data_loaded = get_last_coverage_loaded_time(cov)
 

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -309,7 +309,7 @@ class ArtemisTestFixture(CommonTestFixture):
 
         return _res.get('status', {}).get('last_rt_data_loaded', object())
 
-    @retry(stop_max_delay=25000, wait_fixed=500)
+    @retry(stop_max_delay=60000, wait_fixed=500)
     def wait_for_rt_reload(self, last_rt_data_loaded, cov):
         if self.check_ref:
             return

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -86,8 +86,7 @@ class GuichetUnique(object):
         linked to http://jira.canaltp.fr/browse/NAVITIAII-2000
         """
         self.journey(_from="stop_area:OCE:SA:87296004",
-                     to="stop_area:OCE:SA:87313270", datetime="20121123T2019",
-                     _override_scenario="new_default")
+                     to="stop_area:OCE:SA:87313270", datetime="20121123T2019")
 
     """
     test RealTime on SNCF (COTS)


### PR DESCRIPTION
Passed from 25s to 1min.
Also minor unrelated changes (see commit messages).

TODO (`do_not_merge` labels this):
- [x] wait and check that https://ci.navitia.io/view/artemis/job/custom_artemis_reference_branch_and_artemis_branch_build/212/console is OK