### PR TITLE
[Cots]: Activate tests on added trip

### DIFF
--- a/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_deleted.json
+++ b/artemis/tests/fixtures/trip_add_paris_marseille_with_delay_15_and_stop_time_deleted.json
@@ -140,7 +140,7 @@
           "heureLocale": "13:10:00",
           "idFuseauHoraire": "Europe/Paris",
           "nbJoursPasseMinuit": 0,
-          "statutCirculationOPE": "CREATION"
+          "statutCirculationOPE": "SUPPRESSION"
         }
       },
       {

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -22,6 +22,7 @@ class GuichetUnique(object):
         For each GuichetUnique test with realtime (cots) we should reload kraken
         """
         self.kill_the_krakens()
+        self.pop_krakens()
 
     def test_guichet_unique_paris_to_rouen(self):
         """
@@ -1073,7 +1074,7 @@ class GuichetUnique(object):
         1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Return to normal
-        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        Attention: Since physical_mode:LongDistanceTrain is absent in NTFS, physical_mode:Bike is
         used in the vehicle_journey.
         """
         """
@@ -1332,7 +1333,7 @@ class GuichetUnique(object):
         Realtime request with datetime: 2012/11/20 12:55:00
         From: gare de Auxerre-St-Gervais
         To:   gare de Marseille-St-Charles (Marseille)
-        Should have a solution with departure at 13:00 and arrival at 17:00
+        Should have a solution with departure at 13:10 and arrival at 17:00
         """
         self.journey(_from="stop_area:OCE:SA:87683573",
                      to="stop_area:OCE:SA:87751008",

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -16,6 +16,13 @@ def clean_kirin_db_before_each_test():
 class GuichetUnique(object):
     """
     """
+    @pytest.fixture(scope='function', autouse=True)
+    def kill_kraken_before_each_test(self):
+        """
+        For each GuichetUnique test with realtime (cots) we should reload kraken
+        """
+        self.kill_the_krakens()
+
     def test_guichet_unique_paris_to_rouen(self):
         """
         ID artemis v1: 1
@@ -1061,12 +1068,13 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="realtime")
 
-    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_sequence_11(self):
         """
         1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Return to normal
+        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        used in the vehicle_journey.
         """
         """
         Requested datetime: 2012/11/20 11:55:00
@@ -1134,13 +1142,14 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="realtime")
 
-    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_sequence_12(self):
         """
         1. A simple trip addition with 5 stop_times all existing in navitia
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a stop_time (gare de Auxerre-St-Gervais) deleted in the above flux cots
         4. Return to normal
+        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        used in the vehicle_journey.
         """
         """
         Requested datetime: 2012/11/20 12:55:00
@@ -1170,7 +1179,7 @@ class GuichetUnique(object):
 
         """
         Realtime request with same parameters as above
-        Should have a solution with departure at 13:00 and arrival at 17:00
+        Should have a solution with departure at 13:10 and arrival at 17:00
         """
         self.journey(_from="stop_area:OCE:SA:87683573",
                      to="stop_area:OCE:SA:87751008",
@@ -1185,7 +1194,7 @@ class GuichetUnique(object):
 
         """
         Realtime request with same parameters as above
-        Should have a solution with departure at 13:15 and arrival at 17:15
+        Should have a solution with departure at 13:25 and arrival at 17:15
         """
         self.journey(_from="stop_area:OCE:SA:87683573",
                      to="stop_area:OCE:SA:87751008",
@@ -1215,7 +1224,7 @@ class GuichetUnique(object):
 
         """
         Realtime request with same parameters as above
-        Should have a solution with departure at 13:00 and arrival at 17:00
+        Should have a solution with departure at 13:10 and arrival at 17:00
         """
         self.journey(_from="stop_area:OCE:SA:87683573",
                      to="stop_area:OCE:SA:87751008",
@@ -1223,7 +1232,6 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="realtime")
 
-    @xfail(reason="Waiting for NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_trip_sequence_2(self):
         """
         1. A simple trip addition with 5 stop_times all existing in navitia
@@ -1231,6 +1239,8 @@ class GuichetUnique(object):
         3. Trip modified with a new stop_time (gare de Orleans) added in the above flux cots
         4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
         5. Add again the same trip as 1.
+        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        used in the vehicle_journey.
         """
         """
         Requested datetime: 2012/11/20 12:55:00
@@ -1449,7 +1459,6 @@ class GuichetUnique(object):
                      max_nb_transfers="0",
                      data_freshness="realtime")
 
-    @xfail(reason="Waiting for fix - NAVP-1035", raises=AssertionError, strict=True)
     def test_kirin_cots_add_and_remove_new_course(self):
         """
         Test the addition of a circulation and then, the removal of the added circulation
@@ -1459,7 +1468,7 @@ class GuichetUnique(object):
         To:   gare de Marseille-St-Charles
 
         Before added circulation, no solution can be found without transfer.
-        After added circulation, a train travels from 13:00:00 to 17:00:00
+        After added circulation, a train travels from 13:10:00 to 17:00:00
         """
         self.send_and_wait('trip_add_new_trip_151515.json')
 

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1145,7 +1145,7 @@ class GuichetUnique(object):
         2. Trip modified with 15 minutes delay in each stop_times
         3. Trip modified with a stop_time (gare de Auxerre-St-Gervais) deleted in the above flux cots
         4. Return to normal
-        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        Attention: Since physical_mode:LongDistanceTrain is absent in NTFS, physical_mode:Bike is
         used in the vehicle_journey.
         """
         # Reload kraken
@@ -1240,7 +1240,7 @@ class GuichetUnique(object):
         3. Trip modified with a new stop_time (gare de Orleans) added in the above flux cots
         4. Delete the trip with "statutCirculationOPE": "SUPPRESSION" in all stop_times
         5. Add again the same trip as 1.
-        Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
+        Attention: Since physical_mode:LongDistanceTrain is absent in NTFS, physical_mode:Bike is
         used in the vehicle_journey.
         """
         # Reload kraken

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -16,14 +16,6 @@ def clean_kirin_db_before_each_test():
 class GuichetUnique(object):
     """
     """
-    @pytest.fixture(scope='function', autouse=True)
-    def kill_kraken_before_each_test(self):
-        """
-        For each GuichetUnique test with realtime (cots) we should reload kraken
-        """
-        self.kill_the_krakens()
-        self.pop_krakens()
-
     def test_guichet_unique_paris_to_rouen(self):
         """
         ID artemis v1: 1
@@ -1077,6 +1069,10 @@ class GuichetUnique(object):
         Attention: Since physical_mode:LongDistanceTrain is absent in NTFS, physical_mode:Bike is
         used in the vehicle_journey.
         """
+        # Reload kraken
+        self.kill_the_krakens()
+        self.pop_krakens()
+
         """
         Requested datetime: 2012/11/20 11:55:00
         From: gare de Paris-Montparnasse 1-2 (Paris)
@@ -1152,6 +1148,10 @@ class GuichetUnique(object):
         Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
         used in the vehicle_journey.
         """
+        # Reload kraken
+        self.kill_the_krakens()
+        self.pop_krakens()
+
         """
         Requested datetime: 2012/11/20 12:55:00
         From: gare de Auxerre-St-Gervais
@@ -1243,6 +1243,10 @@ class GuichetUnique(object):
         Attention: Since physical_mode:LongDistanceTrain is absent in Database, physical_mode:Bike is
         used in the vehicle_journey.
         """
+        # Reload kraken
+        self.kill_the_krakens()
+        self.pop_krakens()
+
         """
         Requested datetime: 2012/11/20 12:55:00
         From: gare de Orleans
@@ -1471,6 +1475,10 @@ class GuichetUnique(object):
         Before added circulation, no solution can be found without transfer.
         After added circulation, a train travels from 13:10:00 to 17:00:00
         """
+        # Reload kraken
+        self.kill_the_krakens()
+        self.pop_krakens()
+
         self.send_and_wait('trip_add_new_trip_151515.json')
 
         self.journey(_from="stop_area:OCE:SA:87683573",


### PR DESCRIPTION
Concerns: https://jira.kisio.org/browse/NAVP-1251

TODO:
- [x] merge https://github.com/CanalTP/artemis_references/pull/166 before

With kraken reloaded before each test, GuichetUniqueTest takes 9 minutes more then before.(28 minutes instead of 19 minutes)