### PR TITLE
artemis: init two contributors

### DIFF
--- a/artemis/common_fixture.py
+++ b/artemis/common_fixture.py
@@ -28,6 +28,16 @@ def clean_kirin_db():
         truncate_tables(cur, ', '.join(e[0] for e in tables if e[0] not in ("layer", "topology")))
 
         conn.commit()
+
+        cur.execute(
+            "INSERT INTO contributor SELECT 'realtime.sherbrooke','ca-qc-sherbrooke','token_to_be_modified',"
+            "'feed_url_to_be_modified','gtfs-rt'"
+        )
+        cur.execute(
+            "INSERT INTO contributor SELECT 'realtime.cots','sncf','token_to_be_modified',"
+            "'feed_url_to_be_modified','cots'"
+        )
+        conn.commit()
         logger.debug("kirin db purge done")
     except:
         logger.exception("problem with kirin db")


### PR DESCRIPTION
Adds two contributors : "realtime.sherbrooke" and "realtime.cots" while cleaning the database kirin for each test

Note: Test on "guichet_unique_test" inserts two contributors and all tests are valide