### PR TITLE
fix when ref/out journeys if empty

### DIFF
--- a/artemis/pytest_report_makers.py
+++ b/artemis/pytest_report_makers.py
@@ -1,13 +1,24 @@
 import ujson as json
 import jsondiff
 
+
 def journeys_diff(ref, output):
     with open(ref) as ref_f, open(output) as output_f:
-        ref_j = json.load(ref_f)
-        out_j = json.load(output_f)
-        diff = jsondiff.diff(ref_j['response'].get('journeys', []), out_j['response'].get('journeys', []),
-                             syntax='symmetric')
+        ref_json = json.load(ref_f)
+        out_json = json.load(output_f)
 
+        ref_journey = ref_json.get('response', {}).get('journeys') or []
+        out_journey = out_json.get('response', {}).get('journeys') or []
+
+        if not all((ref_journey,  out_journey)):
+            # in case where ref_journey/out_journey is empty, the diff becomes a list, here we build the diff ourselves
+            if not ref_journey:
+                diff = {jsondiff.symbols.insert
+                        if not ref_journey
+                        else jsondiff.symbols.delete: [[i, j] for i, j in enumerate(out_journey
+        else:
+            diff = jsondiff.diff(ref_journey, out_journey, syntax='symmetric')
+	
         updated_nb = sum(str(k).isdigit() for k in diff.keys())
 
         message = (
@@ -26,6 +37,7 @@ def journeys_diff(ref, output):
 
 def ptref_diff(ref, output):
     return "* ptref diff not yet implemented"
+
 
 def example_diff(ref, output):
     return "* example diff not yet implemented"


### PR DESCRIPTION
Artemis failure report raised exception when `journeys` is empty in ref/output
