### PR TITLE
Artemis Improvements

### DIFF
--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -10,7 +10,6 @@ from retrying import Retrying, retry, RetryError
 from artemis import default_checker
 from artemis import utils
 from artemis.configuration_manager import config
-import datetime
 from artemis.common_fixture import CommonTestFixture, truncate_tables
 
 _tyr = config["TYR_DIR"] + "/manage.py"
@@ -18,57 +17,6 @@ _tyr_config_file = config["TYR_DIR"] + "/settings.py"
 
 # to limit the permissions of the jenkins user on the artemis platform, we create a proxy for all kraken services
 _kraken_wrapper = "/usr/local/bin/kraken_service_wrapper"
-
-
-def dir_path(dataset):
-    p = config["DATASET_PATH_LAYOUT"]
-    return p.format(dataset=dataset)
-
-
-def nav_path(dataset):
-    p = config["NAV_FILE_PATH_LAYOUT"]
-    return p.format(dataset=dataset)
-
-
-class DataSet(object):
-    def __init__(
-        self,
-        name,
-        reload_timeout=datetime.timedelta(minutes=2),
-        fixed_wait=datetime.timedelta(seconds=1),
-        scenario="default",
-    ):
-        self.name = name
-        self.scenario = scenario
-        self.reload_timeout = reload_timeout
-        self.fixed_wait = fixed_wait
-
-    def __str__(self):
-        return self.name
-
-
-def set_scenario(config):
-    def deco(cls):
-        cls.data_sets = []
-        for c in cls.__bases__:
-            if hasattr(c, "data_sets"):
-                for dataset in c.data_sets:
-                    cls.data_sets.append(
-                        DataSet(
-                            name=dataset.name,
-                            reload_timeout=dataset.reload_timeout,
-                            fixed_wait=dataset.fixed_wait,
-                            scenario=dataset.scenario,
-                        )
-                    )
-        if config:
-            for dataset in cls.data_sets:
-                conf = config.get(dataset.name, None)
-                if conf:
-                    dataset.scenario = conf.get("scenario", "default")
-        return cls
-
-    return deco
 
 
 def kraken_status(data_set):
@@ -513,17 +461,3 @@ class ArtemisTestFixture(CommonTestFixture):
     def call_autocomplete(self, place):
         # TODO!
         pass
-
-
-def dataset(datasets):
-    """
-    decorator giving class attribute 'data_sets'
-
-    each test should have this decorator to make clear the data set used for the tests
-    """
-
-    def deco(cls):
-        cls.data_sets = datasets
-        return cls
-
-    return deco

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -56,8 +56,8 @@ def set_scenario(config):
                     cls.data_sets.append(
                         DataSet(
                             name=dataset.name,
-                            reload_timeout=datetime.timedelta(minutes=2),
-                            fixed_wait=datetime.timedelta(seconds=1),
+                            reload_timeout=dataset.reload_timeout,
+                            fixed_wait=dataset.fixed_wait,
                             scenario=dataset.scenario,
                         )
                     )

--- a/artemis/tests/airport01_test.py
+++ b/artemis/tests/airport01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/airport_test.py
+++ b/artemis/tests/airport_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/art_test_01_test.py
+++ b/artemis/tests/art_test_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/art_test_02_test.py
+++ b/artemis/tests/art_test_02_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/art_test_03_test.py
+++ b/artemis/tests/art_test_03_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/auvergne_test.py
+++ b/artemis/tests/auvergne_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 
@@ -279,7 +279,6 @@ class Auvergne(object):
             direct_path_mode=["bike"],
         )
 
-
     def test_direct_path_with_non_default_speed(self):
         """
         Here we test the direct_path by bike with a non default bike_speed
@@ -290,10 +289,10 @@ class Auvergne(object):
             "_from": "3.08390;45.88953",
             "to": "3.13801;45.91932",
             "datetime": "20160118T120300",
-            "first_section_mode": ['bike'],
+            "first_section_mode": ["bike"],
             "direct_path_mode": ["bike"],
             "direct_path": "only",
-            "bike_speed": 1
+            "bike_speed": 1,
         }
         if isinstance(self, TestAuvergneNewDefault):
             # we want to have this direct_path with new_default

--- a/artemis/tests/bibus_test.py
+++ b/artemis/tests/bibus_test.py
@@ -1,6 +1,6 @@
 from artemis import default_checker
 from artemis.default_checker import stop_schedule_checker
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/boucle_01_test.py
+++ b/artemis/tests/boucle_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 # TODO: rename the test

--- a/artemis/tests/corr_01_test.py
+++ b/artemis/tests/corr_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/corr_02_test.py
+++ b/artemis/tests/corr_02_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/freqgtfs_01_test.py
+++ b/artemis/tests/freqgtfs_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/freqgtfs_test.py
+++ b/artemis/tests/freqgtfs_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/freqparis_test.py
+++ b/artemis/tests/freqparis_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/freqsimple_test.py
+++ b/artemis/tests/freqsimple_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -1,5 +1,4 @@
-from artemis.common_fixture import clean_kirin_db
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import clean_kirin_db, dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import datetime
 from artemis.configuration_manager import config

--- a/artemis/tests/itl_test.py
+++ b/artemis/tests/itl_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/map_test.py
+++ b/artemis/tests/map_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/mdi_test.py
+++ b/artemis/tests/mdi_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/mission_test.py
+++ b/artemis/tests/mission_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/nb_corr_01_test.py
+++ b/artemis/tests/nb_corr_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/nb_corr_02_test.py
+++ b/artemis/tests/nb_corr_02_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/nb_corr_03_test.py
+++ b/artemis/tests/nb_corr_03_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/nb_corr_04_test.py
+++ b/artemis/tests/nb_corr_04_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/nb_corr_05_test.py
+++ b/artemis/tests/nb_corr_05_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/passe_minuit_01_test.py
+++ b/artemis/tests/passe_minuit_01_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/passe_minuit_02_test.py
+++ b/artemis/tests/passe_minuit_02_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/poitiers_test.py
+++ b/artemis/tests/poitiers_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/prolong_auto_test.py
+++ b/artemis/tests/prolong_auto_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/prolong_mano_test.py
+++ b/artemis/tests/prolong_mano_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/rebroussement_test.py
+++ b/artemis/tests/rebroussement_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 #

--- a/artemis/tests/saintomer_tad_test.py
+++ b/artemis/tests/saintomer_tad_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/sherbrooke_test.py
+++ b/artemis/tests/sherbrooke_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
 

--- a/artemis/tests/tad_test.py
+++ b/artemis/tests/tad_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 

--- a/artemis/tests/tcl_test.py
+++ b/artemis/tests/tcl_test.py
@@ -1,4 +1,4 @@
-from artemis.test_mechanism import dataset, DataSet, set_scenario
+from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 
 


### PR DESCRIPTION
- Do not override default values on dataset :
For idfm dataset, the timeout values are greater than others and they were overridden when setting scenario (how was it supposed to work on ArtemisOld?)
- Functions used by Artemis Old & NG move to common_fixture
- Run pre-commit on a new test that wasn't "blackified" before merge...

Artemis Old run with these modifications:
https://ci.navitia.io/view/custom_artemis/job/custom_artemis_reference_branch_and_artemis_branch_build/272/