### PR TITLE
[ArtemisNG] Monitor Tyr jobs during binarization

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -189,15 +189,15 @@ class ArtemisTestFixture(CommonTestFixture):
                 )
                 if job_creation > time_limit:
                     if data_type in [dataset["type"] for dataset in job["data_sets"]]:
-                        if job["state"] == "running":
-                            raise utils.RetryError(
-                                "Job with dataset '{}' still running...".format(
-                                    data_type
-                                )
-                            )
-                        elif job["state"] == "done":
+                        if job["state"] == "done":
                             logger.info("Job with dataset '{}' done!".format(data_type))
                             return
+                        elif job["state"] != "failed":
+                            raise utils.RetryError(
+                                "Job with dataset '{type}' still in process ({state})".format(
+                                    type=data_type, state=job["state"]
+                                )
+                            )
                         else:
                             raise Exception(
                                 "Job with dataset '{type}' in state '{state}'".format(

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -293,7 +293,6 @@ class ArtemisTestFixture(CommonTestFixture):
                 jobs_type_to_process.append(job_type)
 
         for type in jobs_type_to_process:
-            logger.info("MBO: Wait for job ")
             wait_for_job_completion(type, current_utc_datetime)
 
         # Wait until data is reloaded

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -281,7 +281,6 @@ class ArtemisTestFixture(CommonTestFixture):
         data_to_process = [
             ("fusio", "fusio", ".txt", True),
             ("osm", "osm", ".pbf", False),
-            ("poi", "poi", ".txt", True),
             ("fusio-poi", "poi", ".txt", True),
             ("geopal", "geopal", ".txt", True),
             ("fusio-geopal", "geopal", ".txt", True),

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import docker
 import tarfile
 import zipfile
+import datetime
 from retrying import retry
 from artemis import default_checker, utils
 from artemis.configuration_manager import config
@@ -164,7 +165,50 @@ class ArtemisTestFixture(CommonTestFixture):
             _response, _, _ = utils.request("coverage/{cov}/status".format(cov=cov))
             return _response.get("status", {}).get("last_load_at", "")
 
-        # wait 5 min at most
+        @retry(
+            stop_max_delay=data_set.reload_timeout.total_seconds() * 1000,
+            wait_fixed=data_set.fixed_wait.total_seconds() * 1000,
+            retry_on_exception=utils.is_retry_exception,
+        )
+        def wait_for_job_completion(data_type, time_limit):
+            """
+            Wait until the data passed to Tyr is processed by checking the associated job status
+            :param data_type: Type of data passed to Tyr
+            :param time_limit: Time limit from when the job could have been created
+            :return: When job is "done"
+            """
+            instance_jobs_url = "{base_url}/v0/jobs/{instance}".format(
+                base_url=config["URL_TYR"], instance=data_set
+            )
+            r = requests.get(instance_jobs_url)
+            r.raise_for_status()
+            jobs_resp = json.loads(r.text)["jobs"]
+            for job in jobs_resp:
+                job_creation = datetime.datetime.strptime(
+                    job["created_at"], "%Y-%m-%dT%H:%M:%S.%f"
+                )
+                if job_creation > time_limit:
+                    if data_type in [dataset["type"] for dataset in job["data_sets"]]:
+                        if job["state"] == "running":
+                            raise utils.RetryError(
+                                "Job with dataset '{}' still running...".format(
+                                    data_type
+                                )
+                            )
+                        elif job["state"] == "done":
+                            logger.info("Job with dataset '{}' done!".format(data_type))
+                            return
+                        else:
+                            raise Exception(
+                                "Job with dataset '{type}' in state '{state}'".format(
+                                    type=data_type, state=job["state"]
+                                )
+                            )
+            raise utils.RetryError(
+                "Job with dataset '{}' not yet created ".format(data_type)
+            )
+
+        # Wait 5 min max
         @retry(
             stop_max_delay=300000,
             wait_fixed=500,
@@ -198,6 +242,7 @@ class ArtemisTestFixture(CommonTestFixture):
         last_reload_time = get_last_coverage_loaded_time(cov=data_set.name)
 
         def put_data(data_type, file_suffix, zipped):
+            process_data = False
             path = "{}/{}/{}".format(data_path, data_set.name, data_type)
             zip_file = "{}/{}_{}.zip".format(path, data_set.name, data_type)
 
@@ -223,22 +268,33 @@ class ArtemisTestFixture(CommonTestFixture):
                 # send the tar to the volume
                 with open("./{}.tar".format(data_type), "rb") as f:
                     containers[0].put_archive(input_path, f.read())
+                    process_data = True
             else:
                 logger.warning("{} path does not exist : {}".format(data_type, path))
 
-        # put the fusio data
-        put_data("fusio", ".txt", zipped=True)
-        # put the osm data
-        put_data("osm", ".pbf", zipped=False)
+            return process_data
 
-        # put the poi data
-        put_data("poi", ".txt", zipped=True)
-        put_data("fusio-poi", ".txt", zipped=True)
+        # Get current datetime to check jobs created from now
+        current_utc_datetime = datetime.datetime.utcnow()
 
-        # put the geopal data
-        put_data("geopal", ".txt", zipped=True)
-        put_data("fusio-geopal", ".txt", zipped=True)
-        put_data("fusio-address", ".txt", zipped=True)
+        # List of tuples representing (type of data, type of job, files extension, is zipped)
+        data_to_process = [
+            ("fusio", "fusio", ".txt", True),
+            ("osm", "osm", ".pbf", False),
+            ("poi", "poi", ".txt", True),
+            ("fusio-poi", "poi", ".txt", True),
+            ("geopal", "geopal", ".txt", True),
+            ("fusio-geopal", "geopal", ".txt", True),
+        ]
+
+        jobs_type_to_process = []
+        for data_type, job_type, file_ext, is_zipped in data_to_process:
+            if put_data(data_type, file_ext, is_zipped):
+                jobs_type_to_process.append(job_type)
+
+        for type in jobs_type_to_process:
+            logger.info("MBO: Wait for job ")
+            wait_for_job_completion(type, current_utc_datetime)
 
         # Wait until data is reloaded
         wait_for_kraken_reload(last_reload_time, data_set.name)

--- a/artemis/conftest.py
+++ b/artemis/conftest.py
@@ -50,7 +50,7 @@ def load_cities(request):
 
     @retry(
         stop_max_delay=300000,
-        wait_fixed=500,
+        wait_fixed=1000,
         retry_on_exception=utils.is_retry_exception,
     )
     def wait_for_cities_completion():

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -34,8 +34,8 @@ IDFM_PARAMS.update(
     [
         DataSet(
             "idfm",
-            reload_timeout=datetime.timedelta(minutes=5),
-            fixed_wait=datetime.timedelta(seconds=10),
+            reload_timeout=datetime.timedelta(minutes=15),
+            fixed_wait=datetime.timedelta(seconds=20),
         )
     ]
 )


### PR DESCRIPTION
Instead of waiting a loooong time for Kraken to restart, ArtemisNG now monitors Tyr jobs to check how is the binarization going.
https://jira.kisio.org/browse/NAVP-1415

Next step to complete this PR:
Have only one dataset by job for a better monitoring and a better future on the NG planet.
https://jira.kisio.org/browse/NAVP-1466

**Side quests**:
- query cities db status less often
- remove unused data type 'poi' because there's no folder 'poi' in artemis_data
- longer timeout for IdfM binarization (fusio2ed can last >10min)