### PR TITLE
Print out explicit exception on clean_kirin_db error

### DIFF
--- a/artemis/common_fixture.py
+++ b/artemis/common_fixture.py
@@ -45,10 +45,11 @@ def clean_kirin_db():
         )
         conn.commit()
         logger.debug("kirin db purge done")
-    except Exception:
-        logger.exception("problem with kirin db")
+    except Exception as e:
+        error_msg = "Problem while cleaning Kirin Db with error : {}".format(str(e))
+        logger.exception(error_msg)
         conn.close()
-        assert False, "problem while cleaning kirin db"
+        assert False, error_msg
     conn.close()
 
 


### PR DESCRIPTION
It happens that our CI fails on cleaning Kirin's DB. 
To help trouble shoot the issue, we need more information on the matter. 