### PR TITLE
[ArtemisNG] Use pytest markers

### DIFF
--- a/artemis/docker_orchestrator.py
+++ b/artemis/docker_orchestrator.py
@@ -206,7 +206,7 @@ def launch_coverages(coverages):
 
             # Run pytest
             test_class = instance[instance_name]["test_class"]
-            p = pytest.main([test_path, "-k", test_class, "--tb=no"])
+            p = pytest.main([test_path, "-m", test_class, "--tb=no"])
             # Check 'pytest.ExitCode.OK' which is 0. Enum available from version > 5
             if p != 0:
                 has_failures = True
@@ -273,4 +273,5 @@ if __name__ == "__main__":
     if args["clean"] or args["test"]:
         docker_clean()
 
-    assert not f
+    if f:
+        raise Exception("Some tests FAILED")

--- a/artemis/tests/airport01_test.py
+++ b/artemis/tests/airport01_test.py
@@ -5,6 +5,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Airport1
 @dataset([DataSet("airport-01")])
 class Airport1(object):
     """

--- a/artemis/tests/airport_test.py
+++ b/artemis/tests/airport_test.py
@@ -5,6 +5,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Airport
 @dataset([DataSet("airport")])
 class Airport(object):
     """

--- a/artemis/tests/art_test_01_test.py
+++ b/artemis/tests/art_test_01_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.ArtTest01
 @dataset([DataSet("test-01")])
 class ArtTest01(object):
     """

--- a/artemis/tests/art_test_02_test.py
+++ b/artemis/tests/art_test_02_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.ArtTest02
 @dataset([DataSet("test-02")])
 class ArtTest02(object):
     """

--- a/artemis/tests/art_test_03_test.py
+++ b/artemis/tests/art_test_03_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.ArtTest03
 @dataset([DataSet("test-03")])
 class ArtTest03(object):
     """

--- a/artemis/tests/auvergne_test.py
+++ b/artemis/tests/auvergne_test.py
@@ -5,6 +5,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Auvergne
 @dataset([DataSet("fr-auv")])
 class Auvergne(object):
     """

--- a/artemis/tests/bibus_test.py
+++ b/artemis/tests/bibus_test.py
@@ -7,6 +7,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Bibus
 @dataset([DataSet("bibus")])
 class Bibus(object):
     """

--- a/artemis/tests/boucle_01_test.py
+++ b/artemis/tests/boucle_01_test.py
@@ -1,9 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
-# TODO: rename the test
 
-
+@pytest.mark.Boucle01
 @dataset([DataSet("boucle-01")])
 class Boucle01(object):
     """

--- a/artemis/tests/corr_01_test.py
+++ b/artemis/tests/corr_01_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Corr01
 @dataset([DataSet("corr-01")])
 class Corr01:
     """

--- a/artemis/tests/corr_02_test.py
+++ b/artemis/tests/corr_02_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Corr02
 @dataset([DataSet("corr-02")])
 class Corr02(object):
     """

--- a/artemis/tests/freqgtfs_01_test.py
+++ b/artemis/tests/freqgtfs_01_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.FreqGtfs_01
 @dataset([DataSet("freqgtfs-01")])
 class FreqGtfs_01(object):
     """

--- a/artemis/tests/freqgtfs_test.py
+++ b/artemis/tests/freqgtfs_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.FreqGtfs
 @dataset([DataSet("freqgtfs")])
 class FreqGtfs(object):
     """

--- a/artemis/tests/freqparis_test.py
+++ b/artemis/tests/freqparis_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.FreqParis
 @dataset([DataSet("freqparis")])
 class FreqParis(object):
     """

--- a/artemis/tests/freqsimple_test.py
+++ b/artemis/tests/freqsimple_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.FreqSimple
 @dataset([DataSet("freqsimple")])
 class FreqSimple(object):
     """

--- a/artemis/tests/guichet_unique_test.py
+++ b/artemis/tests/guichet_unique_test.py
@@ -11,6 +11,7 @@ def clean_kirin_db_before_each_test():
     return clean_kirin_db()
 
 
+@pytest.mark.GuichetUnique
 @dataset([DataSet(COVERAGE)])
 class GuichetUnique(object):
     """

--- a/artemis/tests/idfm_test.py
+++ b/artemis/tests/idfm_test.py
@@ -30,6 +30,7 @@ IDFM_PARAMS.update(
 )
 
 
+@pytest.mark.IdfM
 @dataset(
     [
         DataSet(

--- a/artemis/tests/itl_test.py
+++ b/artemis/tests/itl_test.py
@@ -5,6 +5,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Itl
 @dataset([DataSet("itl")])
 class Itl(object):
     """

--- a/artemis/tests/map_test.py
+++ b/artemis/tests/map_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Map
 @dataset([DataSet("map")])
 class Map(object):
     """

--- a/artemis/tests/mdi_test.py
+++ b/artemis/tests/mdi_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.MDI
 @dataset([DataSet("mdi")])
 class MDI(object):
     """

--- a/artemis/tests/mission_test.py
+++ b/artemis/tests/mission_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Mission
 @dataset([DataSet("mission")])
 class Mission(object):
     """

--- a/artemis/tests/nb_corr_01_test.py
+++ b/artemis/tests/nb_corr_01_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.NbCorr01
 @dataset([DataSet("nb-corr-01")])
 class NbCorr01(object):
     """

--- a/artemis/tests/nb_corr_02_test.py
+++ b/artemis/tests/nb_corr_02_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.NbCorr02
 @dataset([DataSet("nb-corr-02")])
 class NbCorr02(object):
     """

--- a/artemis/tests/nb_corr_03_test.py
+++ b/artemis/tests/nb_corr_03_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.NbCorr03
 @dataset([DataSet("nb-corr-03")])
 class NbCorr03(object):
     """

--- a/artemis/tests/nb_corr_04_test.py
+++ b/artemis/tests/nb_corr_04_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.NbCorr04
 @dataset([DataSet("nb-corr-04")])
 class NbCorr04(object):
     """

--- a/artemis/tests/nb_corr_05_test.py
+++ b/artemis/tests/nb_corr_05_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.NbCorr05
 @dataset([DataSet("nb-corr-05")])
 class NbCorr05(object):
     """

--- a/artemis/tests/passe_minuit_01_test.py
+++ b/artemis/tests/passe_minuit_01_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.PasseMinuit01
 @dataset([DataSet("passe-minuit-01")])
 class PasseMinuit01(object):
     """

--- a/artemis/tests/passe_minuit_02_test.py
+++ b/artemis/tests/passe_minuit_02_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.PasseMinuit02
 @dataset([DataSet("passe-minuit-02")])
 class PasseMinuit02(object):
     """

--- a/artemis/tests/poitiers_test.py
+++ b/artemis/tests/poitiers_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Poitiers
 @dataset([DataSet("poitiers")])
 class Poitiers(object):
     """

--- a/artemis/tests/prolong_auto_test.py
+++ b/artemis/tests/prolong_auto_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.ProlongAuto
 @dataset([DataSet("prolong-auto")])
 class ProlongAuto(object):
     """

--- a/artemis/tests/prolong_mano_test.py
+++ b/artemis/tests/prolong_mano_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.ProlongMano
 @dataset([DataSet("prolong-mano")])
 class ProlongMano(object):
     """

--- a/artemis/tests/rebroussement_test.py
+++ b/artemis/tests/rebroussement_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
-#
+
+@pytest.mark.Rebroussement
 @dataset([DataSet("rebroussement")])
 class Rebroussement(object):
     """

--- a/artemis/tests/saintomer_tad_test.py
+++ b/artemis/tests/saintomer_tad_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.SaintOmer
 @dataset([DataSet("saintomer")])
 class SaintOmer(object):
     """

--- a/artemis/tests/sherbrooke_test.py
+++ b/artemis/tests/sherbrooke_test.py
@@ -5,6 +5,7 @@ import pytest
 xfail = pytest.mark.xfail
 
 
+@pytest.mark.Sherbrooke
 @dataset([DataSet("sherbrooke")])
 class Sherbrooke(object):
     def test_sherbrooke_01(self):

--- a/artemis/tests/tad_test.py
+++ b/artemis/tests/tad_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.Tad
 @dataset([DataSet("tad")])
 class Tad(object):
     """

--- a/artemis/tests/tcl_test.py
+++ b/artemis/tests/tcl_test.py
@@ -1,7 +1,9 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
+import pytest
 
 
+@pytest.mark.TCL
 @dataset([DataSet("tcl")])
 class TCL(object):
     """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,41 @@
 [pytest]
 addopts = --doctest-modules
 norecursedirs = .venv
+
+# Register coverage markers to avoid warnings
+markers =
+    Airport1
+    Airport
+    ArtTest01
+    ArtTest02
+    ArtTest03
+    Auvergne
+    Bibus
+    Boucle01
+    Corr01
+    Corr02
+    FreqGtfs
+    FreqGtfs_01
+    FreqParis
+    FreqSimple
+    GuichetUnique
+    IdfM
+    Itl
+    Map
+    MDI
+    Mission
+    NbCorr01
+    NbCorr02
+    NbCorr03
+    NbCorr04
+    NbCorr05
+    PasseMinuit01
+    PasseMinuit02
+    Poitiers
+    ProlongAuto
+    ProlongMano
+    Rebroussement
+    SaintOmer
+    Sherbrooke
+    Tad
+    TCL


### PR DESCRIPTION
Previously, pytest option `-k` was used (-k EXPRESSION:only run tests which match the given **substring**.)
In the list of coverages to run for navitia: 
- airport, airport-01
- corr-01, nb-corr-01, corr-02, nb-corr-02...
- freqgtfs, freqgtfs-01

So some tests were run because they match the substring but not on the correct coverage.

Now, using markers, it ensures that only tests from the required coverage are run
