### PR TITLE
Un-xfail airport tests

### DIFF
--- a/artemis/tests/airport01_test.py
+++ b/artemis/tests/airport01_test.py
@@ -18,7 +18,6 @@ class Airport1(object):
             datetime="20120904T0700",
         )
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01_02(self):
         self.journey(
             _from="stop_area:AI1:SA:AIRPORTAMS",
@@ -26,7 +25,6 @@ class Airport1(object):
             datetime="20120904T0900",
         )
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01_03(self):
         self.journey(
             _from="stop_area:AI1:SA:AIRPORTAIRPORT",

--- a/artemis/tests/airport_test.py
+++ b/artemis/tests/airport_test.py
@@ -11,7 +11,6 @@ class Airport(object):
     TODO: put there comments about the dataset
     """
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_01(self):
         self.journey(
             _from="stop_area:AIR:SA:AIRPORTAIRPORT",
@@ -19,7 +18,6 @@ class Airport(object):
             datetime="20120904T0700",
         )
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_02(self):
         self.journey(
             _from="stop_area:AIR:SA:AIRPORTAMS",
@@ -27,7 +25,6 @@ class Airport(object):
             datetime="20120904T0900",
         )
 
-    @xfail(reason="http://jira.canaltp.fr/browse/NAVITIAII-1485", raises=AssertionError)
     def test_airport_03(self):
         self.journey(
             _from="stop_area:AIR:SA:AIRPORTAIRPORT",


### PR DESCRIPTION
All tests from coverages "airport" and "airport-01" used to be xfail, but they are actually passing.
So, let's run them!
https://ci.navitia.io/view/custom_artemis/job/custom_artemis_reference_branch_and_artemis_branch_build/304/console

It was related to: https://jira.kisio.org/browse/NAVP-47 that is now closed