### PR TITLE
Add log about RT processing

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -321,26 +321,6 @@ class ArtemisTestFixture(CommonTestFixture):
         """
         pass
 
-    @retry(stop_max_delay=25000, wait_fixed=500)
-    def get_last_rt_loaded_time(self, cov):
-        _res, _, status_code = utils.request("coverage/{cov}/status".format(cov=cov))
-
-        if status_code == 503:
-            raise Exception("Navitia is not available")
-
-        return _res.get("status", {}).get("last_rt_data_loaded", object())
-
-    @retry(stop_max_delay=60000, wait_fixed=500)
-    def wait_for_rt_reload(self, last_rt_data_loaded, cov):
-        logging.warning(
-            "waiting for rt reload later than {}".format(last_rt_data_loaded)
-        )
-        rt_data_loaded = self.get_last_rt_loaded_time(cov)
-
-        if last_rt_data_loaded == rt_data_loaded:
-            raise Exception("real time data not loaded")
-        logger.info("RT data reloaded at {}".format(rt_data_loaded))
-
     def request_compare(self, http_query, checker):
         self.nb_call_to_request_compare += 1
 

--- a/artemis/common_fixture.py
+++ b/artemis/common_fixture.py
@@ -146,7 +146,7 @@ class CommonTestFixture(object):
         )
         logger.info(
             "{test}: RT reloaded in {timedelta}".format(
-                test=self.get_reference_filename_prefix(),
+                test=utils.get_calling_test_function(),
                 timedelta=datetime_rt_data_loaded - datetime_last_rt_data_loaded,
             )
         )

--- a/artemis/common_fixture.py
+++ b/artemis/common_fixture.py
@@ -145,8 +145,9 @@ class CommonTestFixture(object):
             rt_data_loaded, "%Y%m%dT%H%M%S.%f"
         )
         logger.info(
-            "RT reloaded in {}".format(
-                datetime_rt_data_loaded - datetime_last_rt_data_loaded
+            "{test}: RT reloaded in {timedelta}".format(
+                test=self.get_reference_filename_prefix(),
+                timedelta=datetime_rt_data_loaded - datetime_last_rt_data_loaded,
             )
         )
 

--- a/artemis/common_fixture.py
+++ b/artemis/common_fixture.py
@@ -121,8 +121,6 @@ class CommonTestFixture(object):
 
         if last_rt_data_loaded == rt_data_loaded:
             raise Exception("real time data not loaded")
-        else:
-            return rt_data_loaded
 
     def send_and_wait(self, rt_file_name):
         """
@@ -136,18 +134,21 @@ class CommonTestFixture(object):
             logger.warning(" >1 data_set for test class !!!")
         coverage = self.data_sets[0].name
         last_rt_data_loaded = self.get_last_rt_loaded_time(coverage)
-        datetime_last_rt_data_loaded = datetime.datetime.strptime(
-            last_rt_data_loaded, "%Y%m%dT%H%M%S.%f"
-        )
+        start_datetime = datetime.datetime.utcnow()
         self._send_cots(rt_file_name)
-        rt_data_loaded = self.wait_for_rt_reload(last_rt_data_loaded, coverage)
-        datetime_rt_data_loaded = datetime.datetime.strptime(
-            rt_data_loaded, "%Y%m%dT%H%M%S.%f"
-        )
+        cots_processing_time = datetime.datetime.utcnow()
+        self.wait_for_rt_reload(last_rt_data_loaded, coverage)
+        kraken_reloaded_time = datetime.datetime.utcnow()
+
+        def round_time(beginning, end):
+            return round((end - beginning).total_seconds(), 2)
+
         logger.info(
-            "{test}: RT reloaded in {timedelta}".format(
+            "{test}: RT processed in {total}s (Kirin:{kirin}/Kraken:{kraken})".format(
                 test=utils.get_calling_test_function(),
-                timedelta=datetime_rt_data_loaded - datetime_last_rt_data_loaded,
+                total=round_time(start_datetime, kraken_reloaded_time),
+                kirin=round_time(start_datetime, cots_processing_time),
+                kraken=round_time(cots_processing_time, kraken_reloaded_time),
             )
         )
 

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -6,7 +6,7 @@ import psycopg2
 import json
 import pytest
 import inspect
-from retrying import Retrying, retry, RetryError
+from retrying import Retrying, RetryError
 from artemis import default_checker
 from artemis import utils
 from artemis.configuration_manager import config
@@ -320,28 +320,6 @@ class ArtemisTestFixture(CommonTestFixture):
     ###################################
     # wrappers around utils functions #
     ###################################
-
-    @retry(stop_max_delay=25000, wait_fixed=500)
-    def get_last_rt_loaded_time(self, cov):
-        if self.check_ref:
-            return
-
-        _res, _, status_code = utils.request("coverage/{cov}/status".format(cov=cov))
-
-        if status_code == 503:
-            raise Exception("Navitia is not available")
-
-        return _res.get("status", {}).get("last_rt_data_loaded", object())
-
-    @retry(stop_max_delay=60000, wait_fixed=500)
-    def wait_for_rt_reload(self, last_rt_data_loaded, cov):
-        if self.check_ref:
-            return
-
-        rt_data_loaded = self.get_last_rt_loaded_time(cov)
-
-        if last_rt_data_loaded == rt_data_loaded:
-            raise Exception("real time data not loaded")
 
     def api(self, url, response_checker=default_checker.default_checker):
         """


### PR DESCRIPTION
Add log about time spent between sending the COTS feed and Kraken reloading:
```
[2020-03-19 16:14:49,970] [ INFO] [   artemis.common_fixture] test_kirin_cots_trip_detour_at_the_end: RT processed in 28.8s (Kirin:0.43/Kraken:28.37)
```