### PR TITLE
[ArtemisNG] Increase SaintOmer timeout

### DIFF
--- a/artemis/compose_settings.py
+++ b/artemis/compose_settings.py
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# When using ArtemisNG with docker-compose, these parameters will always be the same
+
+USE_ARTEMIS_NG = True
+
+CITIES_DB = "dbname=cities user=navitia host=localhost password=password"
+
+URL_JORMUN = "http://localhost:9191"
+
+JORMUNGANDR_DB = (
+    "dbname=jormungandr user=jormungandr host=localhost password=jormungandr"
+)
+
+URL_TYR = "http://localhost:9898"
+
+KIRIN_API = "http://localhost:9292"
+
+KIRIN_DB = "dbname=kirin user=navitia host=localhost password=navitia port=9494"
+
+KIRIN_API = "http://localhost:9292"

--- a/artemis/tests/saintomer_tad_test.py
+++ b/artemis/tests/saintomer_tad_test.py
@@ -1,10 +1,11 @@
 from artemis.common_fixture import dataset, DataSet, set_scenario
 from artemis.tests.fixture import ArtemisTestFixture
 import pytest
+import datetime
 
 
 @pytest.mark.SaintOmer
-@dataset([DataSet("saintomer")])
+@dataset([DataSet("saintomer", reload_timeout=datetime.timedelta(minutes=3))])
 class SaintOmer(object):
     """
       test "on demand transport"


### PR DESCRIPTION
Several times now that the tests fail due to the timeout for saintomer:
`saintomer: geopal2ed 120.191229492s`

Sidequest:
In order to reduce the command line in Jenkins with env parameters to override, create a file with docker-compose constant params