### PR TITLE
Resp/Ref formatting

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -444,7 +444,7 @@ class ArtemisTestFixture(CommonTestFixture):
             ref.write(
                 json.dumps(
                     reference_text,
-                    indent=4,
+                    indent=2,
                     escape_forward_slashes=False,
                     encode_html_chars=False,
                     ensure_ascii=True,

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -433,7 +433,7 @@ class ArtemisTestFixture(CommonTestFixture):
         }
 
         file_ = open(file_complete_path, "w")
-        file_.write(json.dumps(enhanced_response, indent=2))
+        file_.write(json.dumps(enhanced_response, indent=2, separators=(",", ": ")))
         file_.close()
 
         return filename


### PR DESCRIPTION
First step to remove differences between responses from ArtemisOld and ArtemisNG:
- Remove trailing whitespace from Old responses
- Have the same indent in NG than Old