### PR TITLE
Sort filtered responses for Old and NG

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -436,8 +436,8 @@ class ArtemisTestFixture(CommonTestFixture):
         reference_text["query"] = http_query.replace(
             config["URL_JORMUN"][7:], "localhost"
         )
-        reference_text["response"] = response_checker.filter(
-            json.loads(response_string)
+        reference_text["response"] = utils.order_response(
+            response_checker.filter(json.loads(response_string))
         )
         reference_text["full_response"] = json.loads(
             response_string.replace(config["URL_JORMUN"][7:], "localhost")

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import logging
 import os
 import shutil
@@ -430,14 +430,20 @@ class ArtemisTestFixture(CommonTestFixture):
 
         # to ease debug, we add additional information to the file
         # only the response elt will be compared, so we can add what we want (additional flags or whatever)
-        enhanced_response = {
-            "query": url,
-            "response": filtered_response,
-            "full_response": response,
-        }
+        enhanced_response = OrderedDict(
+            {
+                "query": url,
+                "response": utils.order_response(filtered_response),
+                "full_response": response,
+            }
+        )
 
         file_ = open(file_complete_path, "w")
-        file_.write(json.dumps(enhanced_response, indent=2, separators=(",", ": ")))
+        file_.write(
+            json.dumps(
+                enhanced_response, indent=2, separators=(",", ": "), sort_keys=False
+            )
+        )
         file_.close()
 
         return filename


### PR DESCRIPTION
Sort responses for an easier reading of a diff between responses from NG and Old:
- Before:
![Screenshot from 2020-06-08 18-39-12](https://user-images.githubusercontent.com/35227890/84057246-b0e30a00-a9b7-11ea-8f16-393a79e09d6f.png)
- After:
![Screenshot from 2020-06-08 11-48-59](https://user-images.githubusercontent.com/35227890/84130057-0fa19580-aa43-11ea-9e7c-3f4af904b131.png)

Note: only "short responses" are filtered here. TBD if it's necessary and not time-consuming to also sort "full responses"
