### PR TITLE
Sort Ref responses by keys

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -455,8 +455,8 @@ class ArtemisTestFixture(CommonTestFixture):
         reference_text["query"] = http_query.replace(
             config["URL_JORMUN"][7:], "localhost"
         )
-        reference_text["response"] = response_checker.filter(
-            json.loads(response_string)
+        reference_text["response"] = utils.order_response(
+            response_checker.filter(json.loads(response_string))
         )
         reference_text["full_response"] = json.loads(
             response_string.replace(config["URL_JORMUN"][7:], "localhost")

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -268,24 +268,29 @@ class ArtemisTestFixture(CommonTestFixture):
 
                 logger.info("Zip file has been created : {}".format(archive_filename))
 
-        def put_data(data_type: str, file_suffix):
-            path = "{}/{}/{}".format(data_path, data_set.name, data_type)
+        def put_data(data_types: List[str], file_suffix):
+            for data_type in valid_data_type_path(data_types):
+                path = "{}/{}/{}".format(data_path, data_set.name, data_type)
 
-            logger.info("putting {} data : {}".format(data_type, path))
-            # get all the files names
+                logger.info("putting {} data : {}".format(data_type, path))
+                # get all the files names
 
-            # put them into a zip
-            archive_filename = "{}/{}_{}.zip".format(path, data_set.name, data_type)
-            filenames_to_zip = (f for f in os.listdir(path) if f.endswith(file_suffix))
-            zip_files(filenames_to_zip, archive_filename, path)
+                # put them into a zip
+                archive_filename = "{}/{}_{}.zip".format(path, data_set.name, data_type)
+                filenames_to_zip = (
+                    f for f in os.listdir(path) if f.endswith(file_suffix)
+                )
+                zip_files(filenames_to_zip, archive_filename, path)
 
-            # send the data to Tyr
-            logger.info("Sending {} to {}".format(archive_filename, instance_jobs_url))
-            files_to_post = {"file": open(archive_filename, "rb")}
-            r = requests.post(instance_jobs_url, files=files_to_post)
-            r.raise_for_status()
+                # send the data to Tyr
+                logger.info(
+                    "Sending {} to {}".format(archive_filename, instance_jobs_url)
+                )
+                files_to_post = {"file": open(archive_filename, "rb")}
+                r = requests.post(instance_jobs_url, files=files_to_post)
+                r.raise_for_status()
 
-            logger.debug("Tyr response : {}".format(r.text))
+                logger.debug("Tyr response : {}".format(r.text))
             return True
 
         # Get current datetime to check jobs created from now
@@ -301,8 +306,7 @@ class ArtemisTestFixture(CommonTestFixture):
 
         dataset_types_to_process = []
         for data_files_type, dataset_type, file_ext in data_to_process:
-            for data_type in valid_data_type_path(data_files_type):
-                put_data(data_type, file_ext)
+            if put_data(data_files_type, file_ext):
                 dataset_types_to_process.append(dataset_type)
 
         for dataset_type in dataset_types_to_process:

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -268,29 +268,24 @@ class ArtemisTestFixture(CommonTestFixture):
 
                 logger.info("Zip file has been created : {}".format(archive_filename))
 
-        def put_data(data_types: List[str], file_suffix):
-            for data_type in valid_data_type_path(data_types):
-                path = "{}/{}/{}".format(data_path, data_set.name, data_type)
+        def put_data(data_type: str, file_suffix):
+            path = "{}/{}/{}".format(data_path, data_set.name, data_type)
 
-                logger.info("putting {} data : {}".format(data_type, path))
-                # get all the files names
+            logger.info("putting {} data : {}".format(data_type, path))
+            # get all the files names
 
-                # put them into a zip
-                archive_filename = "{}/{}_{}.zip".format(path, data_set.name, data_type)
-                filenames_to_zip = (
-                    f for f in os.listdir(path) if f.endswith(file_suffix)
-                )
-                zip_files(filenames_to_zip, archive_filename, path)
+            # put them into a zip
+            archive_filename = "{}/{}_{}.zip".format(path, data_set.name, data_type)
+            filenames_to_zip = (f for f in os.listdir(path) if f.endswith(file_suffix))
+            zip_files(filenames_to_zip, archive_filename, path)
 
-                # send the data to Tyr
-                logger.info(
-                    "Sending {} to {}".format(archive_filename, instance_jobs_url)
-                )
-                files_to_post = {"file": open(archive_filename, "rb")}
-                r = requests.post(instance_jobs_url, files=files_to_post)
-                r.raise_for_status()
+            # send the data to Tyr
+            logger.info("Sending {} to {}".format(archive_filename, instance_jobs_url))
+            files_to_post = {"file": open(archive_filename, "rb")}
+            r = requests.post(instance_jobs_url, files=files_to_post)
+            r.raise_for_status()
 
-                logger.debug("Tyr response : {}".format(r.text))
+            logger.debug("Tyr response : {}".format(r.text))
             return True
 
         # Get current datetime to check jobs created from now
@@ -306,7 +301,8 @@ class ArtemisTestFixture(CommonTestFixture):
 
         dataset_types_to_process = []
         for data_files_type, dataset_type, file_ext in data_to_process:
-            if put_data(data_files_type, file_ext):
+            for data_type in valid_data_type_path(data_files_type):
+                put_data(data_type, file_ext)
                 dataset_types_to_process.append(dataset_type)
 
         for dataset_type in dataset_types_to_process:

--- a/artemis/test_mechanism.py
+++ b/artemis/test_mechanism.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import logging
 import os
 import shutil
@@ -430,14 +430,20 @@ class ArtemisTestFixture(CommonTestFixture):
 
         # to ease debug, we add additional information to the file
         # only the response elt will be compared, so we can add what we want (additional flags or whatever)
-        enhanced_response = {
-            "query": url,
-            "response": filtered_response,
-            "full_response": response,
-        }
+        enhanced_response = OrderedDict(
+            {
+                "query": url,
+                "response": utils.order_response(filtered_response),
+                "full_response": response,
+            }
+        )
 
         file_ = open(file_complete_path, "w")
-        file_.write(json.dumps(enhanced_response, indent=2, separators=(",", ": ")))
+        file_.write(
+            json.dumps(
+                enhanced_response, indent=2, separators=(",", ": "), sort_keys=False
+            )
+        )
         file_.close()
 
         return filename

--- a/artemis/utils.py
+++ b/artemis/utils.py
@@ -209,23 +209,20 @@ def order_response(response):
     }
     """
 
-    def sort_response(dictionary):
-        res = OrderedDict()
-        for k, v in sorted(dictionary.items()):
-            if isinstance(v, dict):
-                res[k] = sort_response(v)
-            elif isinstance(v, list):
-                res[k] = []
-                for item in v:
-                    # Navitia response may contain 2 types of list: [dict] and [str]
-                    # If the item in the list is iterable (dict), recursively sort it
-                    # If the item isn't iterable (str), copy the item as is
-                    res[k].append(sort_response(item)) if hasattr(
-                        item, "items"
-                    ) else res[k].append(item)
-            else:
-                res[k] = v
-        return res
+    def sort_response(resp):
+        """
+        Recursively traverse 'resp' param and sort it's sub-dictionaries by keys.
+        List and other objects are keeping the same order
+        """
+        if isinstance(resp, dict):
+            ordered_dict = OrderedDict()
+            for k, v in sorted(resp.items()):
+                ordered_dict[k] = sort_response(v)
+            return ordered_dict
+        elif isinstance(resp, list):
+            return [sort_response(r) for r in resp]
+
+        return resp
 
     # If the response is an OrderedDict, convert it in dict for sorting iteration
     if isinstance(response, OrderedDict):


### PR DESCRIPTION
This work takes its roots in Mehdi's PR (#374) in order to by able to easily compare references between Ye Old Artemis with NG. 

This does not change the nature of the response or the reference. It only change the order of which dictionaries are displayed. Dictionaries are sorted by keys in lexical order, but lists are still preserving the same order.

Requirements :
 - [x] https://github.com/CanalTP/artemis_references/pull/232

