### PR TITLE
[jenkins] wrong artemis with failed messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,13 +107,6 @@ pipeline {
             archiveArtifacts artifacts: 'artemis/logs', allowEmptyArchive :true
         }
         success { echo 'Job is successful, HO YEAH !' }
-        failure {
-            withCredentials([string(credentialsId: 'navitia_core_team_slack_chan', variable: 'NAVITIA_CORE_TEAM_SLACK_CHAN')]) {
-                sh '''
-                    curl -X POST -H 'Content-type: application/json' --data '{"text":":warning: Artemis failed. See https://jenkins-core.canaltp.fr/job/artemis_old/"}' $NAVITIA_CORE_TEAM_SLACK_CHAN
-                '''
-            }
-        }
         cleanup {
             dir("./artemis/") {
             // shutdown dockers

--- a/Jenkinsfile_artemis_old
+++ b/Jenkinsfile_artemis_old
@@ -53,6 +53,13 @@ cf. http://doc.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-
             archiveArtifacts artifacts: 'artemis/logs', allowEmptyArchive :true
         }
         success { echo 'Job is successful, HO YEAH !' }
+        failure {
+            withCredentials([string(credentialsId: 'navitia_core_team_slack_chan', variable: 'NAVITIA_CORE_TEAM_SLACK_CHAN')]) {
+                sh '''
+                    curl -X POST -H 'Content-type: application/json' --data '{"text":":warning: Artemis failed. See https://jenkins-core.canaltp.fr/job/artemis_old/"}' $NAVITIA_CORE_TEAM_SLACK_CHAN
+                '''
+            }
+        }
         cleanup {
             cleanWs()
         }


### PR DESCRIPTION
### Issue
We want to send a message if **Artemis Old** fails, not with **Artemis NG** (for the moment)
I got the wrong file `Jenkinsfile ` -> ` Jenkinsfile_artemis_old `
