### PR TITLE
[CI] Limit artifacts size and jobs on CI

### DIFF
--- a/Jenkinsfile_artemis_old
+++ b/Jenkinsfile_artemis_old
@@ -45,7 +45,8 @@ cf. http://doc.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-
             sshagent(credentials : ['jenkins-core-ssh']) {
                     sh 'rm -rf artemis'
                     sh 'mkdir -p artemis/output '
-                    sh '''scp -r -o StrictHostKeyChecking=no root@par-vm14.srv.canaltp.fr:artemis/output/ artemis/output/  '''
+                    sh '''ssh -o StrictHostKeyChecking=no root@par-vm14.srv.canaltp.fr zip -rqo artemis/output/results.zip artemis/output/*'''
+                    sh '''scp -r -o StrictHostKeyChecking=no root@par-vm14.srv.canaltp.fr:artemis/output/results.zip artemis/output/  '''
                     sh '''scp -o StrictHostKeyChecking=no root@par-vm14.srv.canaltp.fr:artemis/*.xml artemis/  '''
             }
             archiveArtifacts artifacts: 'artemis/output/**/*', allowEmptyArchive :true, fingerprint: true

--- a/Jenkinsfile_artemis_old
+++ b/Jenkinsfile_artemis_old
@@ -12,11 +12,14 @@ pipeline {
 cf. http://doc.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name """)
     }
     options {
-      throttleJobProperty(
-          categories: ['artemis'],
-          throttleEnabled: true,
-          throttleOption: 'category'
-      )
+        throttleJobProperty(
+            categories: ['artemis'],
+            throttleEnabled: true,
+            throttleOption: 'category'
+        )
+        buildDiscarder(
+            logRotator(numToKeepStr: '30')
+        )
     }
     stages {
         stage('Pull data') {


### PR DESCRIPTION
Keep the last 30 jobs on the CI for `artemis_old`.

When zipped, artifacts are ~20MB big, thus 600MB max is going to be used to keep a month of history at 1 build a day. Which is plenty if we want to come back to it.

And we save the polar bears at the same time. #BeGreen

![polar bear](https://media1.giphy.com/media/dAXCusb26nzus180V7/giphy.gif?cid=ecf05e47wjoe59qettpeor9k5ii9t5byatybwlijckubkhfv&rid=giphy.gif)