### PR TITLE
[CI] Fix Jenkins undefined var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
 
                 withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
                     dir("./artemis/navitia-docker-compose/builder_from_package/") {
-                        sh './build.sh -o $GITHUB_TOKEN -t local -e $EVENT -f $FORK -b $BRANCH'
+                        sh "./build.sh -o ${GITHUB_TOKEN} -t local -e ${EVENT} -f ${FORK} -b ${BRANCH}"
                     }
                 }
             }


### PR DESCRIPTION
The variable $EVENT was undefined, but using the syntax ${VAR} and sh double quote (sh " ") should fix the issue. 
Tested on a local jenkins.