### PR TITLE
[CI] Fix Artemis NG

### DIFF
--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -321,12 +321,8 @@ class ArtemisTestFixture(CommonTestFixture):
                 if "tyr_beat" in x.name
             ]
             if not containers:
-                logger.error(
-                    "No Docker Container found for tyr_beat"
-                )
-                raise Exception(
-                    "No Docker Container found for tyr_beat"
-                )
+                logger.error("No Docker Container found for tyr_beat")
+                raise Exception("No Docker Container found for tyr_beat")
             else:
                 containers[0].pause()
 
@@ -342,12 +338,8 @@ class ArtemisTestFixture(CommonTestFixture):
                 if "tyr_beat" in x.name
             ]
             if not containers:
-                logger.error(
-                    "No Docker Container found for tyr_beat"
-                )
-                raise Exception(
-                    "No Docker Container found for tyr_beat"
-                )
+                logger.error("No Docker Container found for tyr_beat")
+                raise Exception("No Docker Container found for tyr_beat")
             else:
                 containers[0].unpause()
 

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -205,7 +205,6 @@ class ArtemisTestFixture(CommonTestFixture):
             :param time_limit: UTC time from when the job could have been created. Allows to exclude jobs from previous bina
             :return: When dataset is "done"
             """
-            # TODO : fetch only jobs in current dataset ex : http://localhost:9898/v0/jobs/test-01
             r = requests.get(instance_jobs_url)
             r.raise_for_status()
             jobs_resp = json.loads(r.text)["jobs"]
@@ -310,6 +309,48 @@ class ArtemisTestFixture(CommonTestFixture):
             logger.debug("Tyr response : {}".format(r.text))
             return True
 
+        def pause_tyr_beat():
+            """
+            Pause tyr_beat executable which lives in tyr_beat container.
+            Pauses all processes within tyr_beat container.
+            """
+            logger.debug("Stopping tyr_beat")
+            containers = [
+                x
+                for x in docker.DockerClient(version="auto").containers.list()
+                if "tyr_beat" in x.name
+            ]
+            if not containers:
+                logger.error(
+                    "No Docker Container found for tyr_beat"
+                )
+                raise Exception(
+                    "No Docker Container found for tyr_beat"
+                )
+            else:
+                containers[0].pause()
+
+        def unpause_tyr_beat():
+            """
+            Unpause tyr_beat executable which lives in tyr_beat container.
+            Unpauses all processes within tyr_beat container.
+            """
+            logger.debug("Starting tyr_beat")
+            containers = [
+                x
+                for x in docker.DockerClient(version="auto").containers.list()
+                if "tyr_beat" in x.name
+            ]
+            if not containers:
+                logger.error(
+                    "No Docker Container found for tyr_beat"
+                )
+                raise Exception(
+                    "No Docker Container found for tyr_beat"
+                )
+            else:
+                containers[0].unpause()
+
         # Get current datetime to check jobs created from now
         current_utc_datetime = datetime.datetime.utcnow()
 
@@ -321,11 +362,18 @@ class ArtemisTestFixture(CommonTestFixture):
             (["geopal", "fusio-geopal"], "geopal", ".txt"),
         ]
 
+        # We must pause tyr_beat to avoid possibly
+        # multiple (partial) binarization and kraken reload
+        # And more importantly test will run with dataset fully binarized
+        pause_tyr_beat()
+
         dataset_types_to_process = []
         for data_files_type, dataset_type, file_ext in data_to_process:
             for data_type in valid_data_type_path(data_files_type):
                 put_data(data_type, file_ext)
                 dataset_types_to_process.append(dataset_type)
+
+        unpause_tyr_beat()
 
         wait_until_instance_jobs_are_done(current_utc_datetime)
         # Wait until data is reloaded

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -365,6 +365,7 @@ class ArtemisTestFixture(CommonTestFixture):
         # We must pause tyr_beat to avoid possibly
         # multiple (partial) binarization and kraken reload
         # And more importantly test will run with dataset fully binarized
+        # For more detail see ticket NAVP-1726
         pause_tyr_beat()
 
         dataset_types_to_process = []

--- a/artemis/base_pytest.py
+++ b/artemis/base_pytest.py
@@ -324,7 +324,8 @@ class ArtemisTestFixture(CommonTestFixture):
                 logger.error("No Docker Container found for tyr_beat")
                 raise Exception("No Docker Container found for tyr_beat")
             else:
-                containers[0].pause()
+                for cn in containers:
+                    cn.pause()
 
         def unpause_tyr_beat():
             """
@@ -341,7 +342,8 @@ class ArtemisTestFixture(CommonTestFixture):
                 logger.error("No Docker Container found for tyr_beat")
                 raise Exception("No Docker Container found for tyr_beat")
             else:
-                containers[0].unpause()
+                for cn in containers:
+                    cn.unpause()
 
         # Get current datetime to check jobs created from now
         current_utc_datetime = datetime.datetime.utcnow()


### PR DESCRIPTION
Previously, Artemis NG was failling at some tests due to a bad binarization. 
See ticket NAVP-1726 for more details

With this fix, we are now sure to do a full binarization only once for each coverage.
We achieved this goal by suspending tyr_beat docker during the data upload (post) to tyr, then we avoid tyr_beat to run a binarization (ed2nav) for each sub part of the data coverage (osm, fusio, poi...)