### PR TITLE
[NG] Improve Artemis NG - Jenkins robustness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
 					sh 'make clean_images TAG=local || exit 0'
 					// FORCE stop and remove artemis containers and images
 					sh 'docker stop \$(docker ps -a -q -f name=artemis) || exit 0'
+					sh 'docker kill \$(docker ps -a -q -f name=artemis) || exit 0'
 					sh 'docker rm \$(docker ps -a -q -f name=artemis) || exit 0'
 					sh 'docker image rm \$(docker images --filter=reference=artemis -q) || exit 0'
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,11 +60,8 @@ pipeline {
 					sh 'make stop TAG=local || exit 0'
 					// remove images
 					sh 'make clean_images TAG=local || exit 0'
-					// FORCE stop and remove artemis containers and images
-					sh 'docker stop \$(docker ps -a -q -f name=artemis) || exit 0'
-					sh 'docker kill \$(docker ps -a -q -f name=artemis) || exit 0'
-					sh 'docker rm \$(docker ps -a -q -f name=artemis) || exit 0'
-					sh 'docker image rm \$(docker images --filter=reference=artemis -q) || exit 0'
+					// Force stop artemis container (container executing tests)
+					sh 'make clean_artemis || exit 0'
 				}
 			}
 		}
@@ -129,10 +126,8 @@ pipeline {
 				sh 'make stop TAG=local || exit 0'
 				// remove images
 				sh 'make clean_images TAG=local || exit 0'
-				// FORCE stop and remove artemis containers and images
-				sh 'docker stop \$(docker ps -a -q -f name=artemis) || exit 0'
-				sh 'docker rm \$(docker ps -a -q -f name=artemis) || exit 0'
-				sh 'docker image rm \$(docker images --filter=reference=artemis -q) || exit 0'
+				// Force stop artemis container (container executing tests)
+				sh 'make clean_artemis || exit 0'
             }
             cleanWs()
         }

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ stop: ## Tear down Navitia stack
 
 clean: ## Remove stopped containers
 	$(call docker_compose,${TAG}, rm --force --stop -v)
-	
+
 clean_artemis: ## Remove artemis container (container executing tests)
 	docker rm --force $$(docker ps -a -q -f name=artemis)
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ stop: ## Tear down Navitia stack
 
 clean: ## Remove stopped containers
 	$(call docker_compose,${TAG}, rm --force --stop -v)
+	
+clean_artemis: ## Remove artemis container (container executing tests)
+	docker rm --force $$(docker ps -a -q -f name=artemis)
 
 clean_images: ## Remove stopped containers
 	$(call docker_compose,${TAG}, down --rmi all)


### PR DESCRIPTION
We enforce the stop of all artemis containers and removes all images at the very beginning of Jenkins Pipeline, to prevent possible bugs due to zombie containers interacting during the test run.