### PR TITLE
[ARTEMIS_NG] Increase cities_db wait time for completion

### DIFF
--- a/artemis/conftest.py
+++ b/artemis/conftest.py
@@ -50,8 +50,8 @@ def load_cities(request):
         return json.loads(r_cities.text)["latest_job"]
 
     @retry(
-        stop_max_delay=300000,
-        wait_fixed=1000,
+        stop_max_delay=900000,
+        wait_fixed=2000,
         retry_on_exception=utils.is_retry_exception,
     )
     def wait_for_cities_db():
@@ -69,8 +69,8 @@ def load_cities(request):
                 raise Exception("Couldn't get 'cities' job status")
 
     @retry(
-        stop_max_delay=300000,
-        wait_fixed=1000,
+        stop_max_delay=900000,
+        wait_fixed=2000,
         retry_on_exception=utils.is_retry_exception,
     )
     def wait_for_cities_completion():


### PR DESCRIPTION
On slow machine ARTEMIS_NG run could fail because of a low timeout for cities_db wait for completion
Before / After
5 min -> 15 min